### PR TITLE
adding migration script options file and support

### DIFF
--- a/elasticsearch-evolution-core/src/main/java/com/senacor/elasticsearch/evolution/core/api/config/ElasticsearchEvolutionConfig.java
+++ b/elasticsearch-evolution-core/src/main/java/com/senacor/elasticsearch/evolution/core/api/config/ElasticsearchEvolutionConfig.java
@@ -31,6 +31,12 @@ public class ElasticsearchEvolutionConfig {
             Collections.singletonList("classpath:es/migration"));
 
     /**
+     * Location of migrations scripts execution options. Supported is classpath:some/path/filename and file:/some/path/filename
+     */
+    private String scriptExecuteOptionsFileLocation = "classpath:es/config";
+    private String scriptExecuteOptionsFileName = "migrationOptions.json";
+
+    /**
      * Encoding of migration files.
      */
     private Charset encoding = StandardCharsets.UTF_8;
@@ -103,6 +109,8 @@ public class ElasticsearchEvolutionConfig {
     public ElasticsearchEvolutionConfig validate() throws IllegalStateException, NullPointerException {
         if (enabled) {
             requireNotEmpty(locations, "locations must not be empty");
+            requireNotEmpty(scriptExecuteOptionsFileLocation, "scriptExecuteOptionsFileLocation must not be empty");
+            requireNotEmpty(scriptExecuteOptionsFileName, "scriptExecuteOptionsFileName must not be empty");
             requireNonNull(encoding, "encoding must not be null");
             requireNotBlank(esMigrationPrefix, "esMigrationPrefix must not be empty");
             requireNotEmpty(esMigrationSuffixes, "esMigrationSuffixes must not be empty");
@@ -141,8 +149,20 @@ public class ElasticsearchEvolutionConfig {
         return locations;
     }
 
+    public String getScriptExecuteOptionsFileLocation() {
+        return scriptExecuteOptionsFileLocation;
+    }
+    public String getScriptExecuteOptionsFileName() {
+        return scriptExecuteOptionsFileName;
+    }
+
     public ElasticsearchEvolutionConfig setLocations(List<String> locations) {
         this.locations = locations;
+        return this;
+    }
+
+    public ElasticsearchEvolutionConfig setScriptExecuteOptionsFileLocation(String scriptExecuteOptionsFileLocation) {
+        this.scriptExecuteOptionsFileLocation = scriptExecuteOptionsFileLocation;
         return this;
     }
 
@@ -241,6 +261,8 @@ public class ElasticsearchEvolutionConfig {
         return "ElasticsearchEvolutionConfig{" +
                 "enabled=" + enabled +
                 ", locations=" + locations +
+                ", scriptExecuteOptionsFileLocation=" + scriptExecuteOptionsFileLocation +
+                ", scriptExecuteOptionsFileName=" + scriptExecuteOptionsFileName +
                 ", encoding=" + encoding +
                 ", defaultContentType='" + defaultContentType + '\'' +
                 ", esMigrationPrefix='" + esMigrationPrefix + '\'' +

--- a/elasticsearch-evolution-core/src/main/java/com/senacor/elasticsearch/evolution/core/api/migration/MigrationScriptOptionsParser.java
+++ b/elasticsearch-evolution-core/src/main/java/com/senacor/elasticsearch/evolution/core/api/migration/MigrationScriptOptionsParser.java
@@ -1,0 +1,21 @@
+package com.senacor.elasticsearch.evolution.core.api.migration;
+
+import com.senacor.elasticsearch.evolution.core.internal.model.migration.MigrationScriptExecuteOptions;
+import com.senacor.elasticsearch.evolution.core.internal.model.migration.ParsedMigrationScript;
+import com.senacor.elasticsearch.evolution.core.internal.model.migration.RawMigrationScript;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * @author Andreas Keefer
+ */
+public interface MigrationScriptOptionsParser {
+    /**
+     * parses all migration scripts
+     *
+     * @param rawMigrationScripts the migration scripts to parse
+     * @return a map of migrationScriptFilename -> {@link MigrationScriptExecuteOptions}
+     */
+    Map<String,MigrationScriptExecuteOptions> parse(Collection<RawMigrationScript> rawMigrationScripts);
+}

--- a/elasticsearch-evolution-core/src/main/java/com/senacor/elasticsearch/evolution/core/internal/migration/input/MigrationScriptExecuteOptionsConfiguration.java
+++ b/elasticsearch-evolution-core/src/main/java/com/senacor/elasticsearch/evolution/core/internal/migration/input/MigrationScriptExecuteOptionsConfiguration.java
@@ -1,0 +1,17 @@
+package com.senacor.elasticsearch.evolution.core.internal.migration.input;
+
+import com.senacor.elasticsearch.evolution.core.internal.model.migration.MigrationScriptExecuteOptions;
+
+import java.util.List;
+
+public class MigrationScriptExecuteOptionsConfiguration {
+    private List<MigrationScriptExecuteOptions> migrationScriptsOptions;
+
+    public List<MigrationScriptExecuteOptions> getMigrationScriptsOptions() {
+        return migrationScriptsOptions;
+    }
+
+    public void setMigrationScriptsOptions(List<MigrationScriptExecuteOptions> migrationScriptsOptions) {
+        this.migrationScriptsOptions = migrationScriptsOptions;
+    }
+}

--- a/elasticsearch-evolution-core/src/main/java/com/senacor/elasticsearch/evolution/core/internal/migration/input/MigrationScriptOptionsParserImpl.java
+++ b/elasticsearch-evolution-core/src/main/java/com/senacor/elasticsearch/evolution/core/internal/migration/input/MigrationScriptOptionsParserImpl.java
@@ -1,0 +1,74 @@
+package com.senacor.elasticsearch.evolution.core.internal.migration.input;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.senacor.elasticsearch.evolution.core.api.MigrationException;
+import com.senacor.elasticsearch.evolution.core.api.migration.MigrationScriptOptionsParser;
+import com.senacor.elasticsearch.evolution.core.internal.model.migration.MigrationScriptExecuteOptions;
+import com.senacor.elasticsearch.evolution.core.internal.model.migration.RawMigrationScript;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.requireNonNull;
+
+public class MigrationScriptOptionsParserImpl implements MigrationScriptOptionsParser {
+
+    private final Map<String, String> placeholders;
+    private final String placeholderPrefix;
+    private final String placeholderSuffix;
+    private final boolean placeholderReplacement;
+
+    private final String scriptExecuteOptionsFileName;
+
+    public MigrationScriptOptionsParserImpl(Map<String, String> placeholders,
+                                     String placeholderPrefix,
+                                     String placeholderSuffix,
+                                     boolean placeholderReplacement,
+                                     String scriptExecuteOptionsFileName) {
+        this.placeholders = placeholders;
+        this.placeholderPrefix = placeholderPrefix;
+        this.placeholderSuffix = placeholderSuffix;
+        this.placeholderReplacement = placeholderReplacement;
+        this.scriptExecuteOptionsFileName = scriptExecuteOptionsFileName;
+    }
+    @Override
+    public Map<String, MigrationScriptExecuteOptions> parse(Collection<RawMigrationScript> rawMigrationScripts) {
+        requireNonNull(rawMigrationScripts, "rawMigrationScripts must not be null");
+        int filesCount = rawMigrationScripts.size();
+        // expecting exactly one script options file
+        if (filesCount == 0) {
+            return Collections.emptyMap();
+        }
+        if (rawMigrationScripts.size() > 1) {
+            throw new MigrationException("found more than one script options file: " + rawMigrationScripts.stream().map(RawMigrationScript::getFileName).collect(Collectors.toList()) );
+        }
+        RawMigrationScript scriptExecuteOptionsFile = rawMigrationScripts.stream().findFirst().get();
+        if (!scriptExecuteOptionsFileName.equals(scriptExecuteOptionsFile.getFileName())) {
+            throw new MigrationException("Could not find script options file: " + scriptExecuteOptionsFileName );
+        }
+        return parse(scriptExecuteOptionsFile).stream()
+                .collect(Collectors.toMap(
+                        s -> s.getFileName(),
+                        s -> s,
+                        (oldVal, newVal) -> {
+                            if (Objects.equals(oldVal.getFileName(), newVal.getFileName())) {
+                                throw new MigrationException("duplicate options for the same file: " + oldVal.getFileName());
+                            } else {
+                                return newVal;
+                            }
+                        }));
+    }
+
+    List<MigrationScriptExecuteOptions> parse(RawMigrationScript rawMigrationScript) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        MigrationScriptExecuteOptionsConfiguration migrationScriptExecuteOptionsConfiguration;
+        try {
+            migrationScriptExecuteOptionsConfiguration = objectMapper.readValue(rawMigrationScript.getContent(), MigrationScriptExecuteOptionsConfiguration.class);
+        } catch (JsonProcessingException e) {
+            throw new MigrationException("failed parsing content of " + rawMigrationScript.getFileName(), e);
+        }
+        return migrationScriptExecuteOptionsConfiguration.getMigrationScriptsOptions();
+    }
+
+}

--- a/elasticsearch-evolution-core/src/main/java/com/senacor/elasticsearch/evolution/core/internal/model/migration/MigrationScriptExecuteOptions.java
+++ b/elasticsearch-evolution-core/src/main/java/com/senacor/elasticsearch/evolution/core/internal/model/migration/MigrationScriptExecuteOptions.java
@@ -1,0 +1,59 @@
+package com.senacor.elasticsearch.evolution.core.internal.model.migration;
+
+import java.util.*;
+
+public class MigrationScriptExecuteOptions {
+
+    /**
+     * script file name without any packages/directories.
+     * Should match an existing migration script name
+     */
+    private String fileName = "";
+
+    /**
+     * List of valid options:
+     */
+
+    /**
+     * Option : ignore Http status codes. When set, those specified codes are always treated as success.
+     * Example: "404"
+     */
+    private List<Integer> ignoredHttpStatusCodes = Collections.emptyList();
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
+    }
+
+    public List<Integer> getIgnoredHttpStatusCodes() {
+        return ignoredHttpStatusCodes;
+    }
+
+    public void setIgnoredHttpStatusCodes(Collection<Integer> ignoredHttpStatusCodes) {
+        this.ignoredHttpStatusCodes = new ArrayList<>(ignoredHttpStatusCodes);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        MigrationScriptExecuteOptions that = (MigrationScriptExecuteOptions) o;
+        return fileName.equals(that.fileName) && ignoredHttpStatusCodes.equals(that.ignoredHttpStatusCodes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(fileName, ignoredHttpStatusCodes);
+    }
+
+    @Override
+    public String toString() {
+        return "MigrationScriptExecuteOptions{" +
+                "fileName='" + fileName + '\'' +
+                ", ignoredHttpStatusCodes=" + ignoredHttpStatusCodes +
+                '}';
+    }
+}

--- a/elasticsearch-evolution-core/src/main/java/com/senacor/elasticsearch/evolution/core/internal/model/migration/ParsedMigrationScript.java
+++ b/elasticsearch-evolution-core/src/main/java/com/senacor/elasticsearch/evolution/core/internal/model/migration/ParsedMigrationScript.java
@@ -28,6 +28,7 @@ public class ParsedMigrationScript {
      * non-null
      */
     private MigrationScriptRequest migrationScriptRequest;
+    private MigrationScriptExecuteOptions migrationScriptExecuteOptions;
 
     public FileNameInfo getFileNameInfo() {
         return fileNameInfo;
@@ -56,18 +57,27 @@ public class ParsedMigrationScript {
         return this;
     }
 
+    public MigrationScriptExecuteOptions getMigrationScriptExecuteOptions() {
+        return migrationScriptExecuteOptions;
+    }
+
+    public void setMigrationScriptExecuteOptions(MigrationScriptExecuteOptions migrationScriptExecuteOptions) {
+        this.migrationScriptExecuteOptions = migrationScriptExecuteOptions;
+    }
+
     @Override
     public String toString() {
         return "ParsedMigrationScript{" +
                 "fileNameInfo=" + fileNameInfo +
                 ", checksum=" + checksum +
                 ", migrationScriptRequest=" + migrationScriptRequest +
+                ", migrationScriptExecuteOptions=" + migrationScriptExecuteOptions +
                 '}';
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(fileNameInfo, checksum, migrationScriptRequest);
+        return Objects.hash(fileNameInfo, checksum, migrationScriptRequest, migrationScriptExecuteOptions);
     }
 
     @Override
@@ -81,6 +91,7 @@ public class ParsedMigrationScript {
         final ParsedMigrationScript other = (ParsedMigrationScript) obj;
         return Objects.equals(this.fileNameInfo, other.fileNameInfo)
                 && Objects.equals(this.checksum, other.checksum)
+                && Objects.equals(this.migrationScriptExecuteOptions, other.migrationScriptExecuteOptions)
                 && Objects.equals(this.migrationScriptRequest, other.migrationScriptRequest);
     }
 }

--- a/elasticsearch-evolution-core/src/test/resources/es/ElasticsearchEvolutionTest/migrate_OK/migrationOptions.json
+++ b/elasticsearch-evolution-core/src/test/resources/es/ElasticsearchEvolutionTest/migrate_OK/migrationOptions.json
@@ -1,0 +1,11 @@
+{
+  "migrationScriptsOptions": [
+    {
+      "fileName": "V001.00__createTemplateWithIndexMapping.http",
+      "ignoredHttpStatusCodes": [
+        404,
+        409
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Enable the ability for adding a new configuration file, with options per migration script.
Not all migration scripts must have a reference in this file, but only selected ones.
The only supported option for now is `ignoredHttpStatusCodes`, but the format allows adding more options in the future..
Example for options file format:
```json
{
  "migrationScriptsOptions": [
    {
      "fileName": "V001.00__createTemplateWithIndexMapping.http",
      "ignoredHttpStatusCodes": [
        404,
        409
      ]
    }
  ]
}

````