### PR TITLE
Migrate org.reflections.reflections from 0.9.12 to 0.10.2

### DIFF
--- a/elasticsearch-evolution-core/src/main/java/com/senacor/elasticsearch/evolution/core/internal/migration/input/MigrationScriptReaderImpl.java
+++ b/elasticsearch-evolution-core/src/main/java/com/senacor/elasticsearch/evolution/core/internal/migration/input/MigrationScriptReaderImpl.java
@@ -152,8 +152,8 @@ public class MigrationScriptReaderImpl implements MigrationScriptReader {
                     .filterInputsBy(new FilterBuilder().includePackage(locationWithoutPrefixAsPackageNotation))
                     .setUrls(urls));
             resources = reflections.getResources(Pattern.compile(esMigrationPrefix + ".*"))
-                    .stream().map(path -> Paths.get(path).getFileName().toString())
-                    .filter(this::isValidFilename)
+                    .stream()
+                    .filter(path -> isValidFilename(Paths.get(path).getFileName().toString()))
                     .collect(Collectors.toSet());
         }
 

--- a/elasticsearch-evolution-core/src/main/java/com/senacor/elasticsearch/evolution/core/internal/migration/input/MigrationScriptReaderImpl.java
+++ b/elasticsearch-evolution-core/src/main/java/com/senacor/elasticsearch/evolution/core/internal/migration/input/MigrationScriptReaderImpl.java
@@ -3,8 +3,9 @@ package com.senacor.elasticsearch.evolution.core.internal.migration.input;
 import com.senacor.elasticsearch.evolution.core.api.MigrationException;
 import com.senacor.elasticsearch.evolution.core.api.migration.MigrationScriptReader;
 import com.senacor.elasticsearch.evolution.core.internal.model.migration.RawMigrationScript;
+import java.util.regex.Pattern;
 import org.reflections.Reflections;
-import org.reflections.scanners.ResourcesScanner;
+import org.reflections.scanners.Scanners;
 import org.reflections.util.ClasspathHelper;
 import org.reflections.util.ConfigurationBuilder;
 import org.reflections.util.FilterBuilder;
@@ -147,10 +148,13 @@ public class MigrationScriptReaderImpl implements MigrationScriptReader {
             resources = emptySet();
         } else {
             Reflections reflections = new Reflections(new ConfigurationBuilder()
-                    .setScanners(new ResourcesScanner())
+                    .setScanners(Scanners.Resources)
                     .filterInputsBy(new FilterBuilder().includePackage(locationWithoutPrefixAsPackageNotation))
                     .setUrls(urls));
-            resources = reflections.getResources(this::isValidFilename);
+            resources = reflections.getResources(Pattern.compile(esMigrationPrefix + ".*"))
+                    .stream().map(path -> Paths.get(path).getFileName().toString())
+                    .filter(this::isValidFilename)
+                    .collect(Collectors.toSet());
         }
 
         return resources.stream().flatMap(resource -> {

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
         <commons-io.version>2.15.0</commons-io.version>
         <!--when updating elasticsearch versions, also update "ElasticsearchContainer" version in EmbeddedElasticsearchExtension-->
         <elasticsearch.version>7.5.2</elasticsearch.version>
-        <reflections.version>0.9.12</reflections.version>
+        <reflections.version>0.10.2</reflections.version>
         <testcontainers.elasticsearch.version>1.19.1</testcontainers.elasticsearch.version>
         <lombok.version>1.18.30</lombok.version>
     </properties>


### PR DESCRIPTION
This PR updates org.reflections:reflections from 0.9.12 to 0.10.2 since I saw [this open issue](https://github.com/ronmamo/reflections/issues/391).
Filtering the resources by prefix and suffix using a regex pattern was possible for both versions, but I also needed to switch from deprecated `new ResourcesScanner()` to `Scanners.Resources` for a working solution.