### PR TITLE
spring-boot version updates and remove deprecated query parameter `ignore_throttled`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Successful executed migration scripts will not be executed again!
 ## 2 Features
 
 - tested on Java 8, 11, 17, and 21
-- runs on Spring-Boot 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 3.0 and 3.1 (and of course without Spring-Boot)
+- runs on Spring-Boot 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 3.0, 3.1 and 3.2 (and of course without Spring-Boot)
 - runs on Elasticsearch version 7.5.x - 8.11.x
 - runs on Opensearch version 1.x and 2.x
 - highly configurable (e.g. location(s) of your migration files, migration files format pattern)
@@ -31,12 +31,12 @@ Successful executed migration scripts will not be executed again!
 - ready to use default configuration
 - line comments in migration files
 
-| Compatibility                    | Spring Boot                                 | Elasticsearch        | Opensearch |
-|----------------------------------|---------------------------------------------|----------------------|------------|
-| elasticsearch-evolution >= 0.4.2 | 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 3.0, 3.1 | 7.5.x - 8.11.x       | 1.x - 2.x  |
-| elasticsearch-evolution >= 0.4.0 | 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7           | 7.5.x - 8.6.x        | 1.x - 2.x  |
-| elasticsearch-evolution 0.3.x    | 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7           | 7.5.x - 7.17.x       |            |
-| elasticsearch-evolution 0.2.x    | 1.5, 2.0, 2.1, 2.2, 2.3, 2.4                | 7.0.x - 7.4.x, 6.8.x |            |
+| Compatibility                    | Spring Boot                                      | Elasticsearch        | Opensearch |
+|----------------------------------|--------------------------------------------------|----------------------|------------|
+| elasticsearch-evolution >= 0.4.2 | 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 3.0, 3.1, 3.2 | 7.5.x - 8.11.x       | 1.x - 2.x  |
+| elasticsearch-evolution >= 0.4.0 | 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7                | 7.5.x - 8.6.x        | 1.x - 2.x  |
+| elasticsearch-evolution 0.3.x    | 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7                | 7.5.x - 7.17.x       |            |
+| elasticsearch-evolution 0.2.x    | 1.5, 2.0, 2.1, 2.2, 2.3, 2.4                     | 7.0.x - 7.4.x, 6.8.x |            |
 
 NOTE: When you run on Java 11 and using spring-boot 2.2 or 2.3 and you hit [this issue](https://github.com/ronmamo/reflections/issues/279), you have 2 options: 
 
@@ -293,7 +293,9 @@ ElasticsearchEvolution.configure()
 
 ### v0.5.1-SNAPSHOT
 
-- ...
+- version updates (spring-boot 2.7.18)
+- added regression tests for spring boot 3.2
+- remove deprecated query parameter `ignore_throttled` from ES requests
 
 ### v0.5.0
 

--- a/elasticsearch-evolution-core/src/main/java/com/senacor/elasticsearch/evolution/core/internal/migration/execution/HistoryRepositoryImpl.java
+++ b/elasticsearch-evolution-core/src/main/java/com/senacor/elasticsearch/evolution/core/internal/migration/execution/HistoryRepositoryImpl.java
@@ -267,7 +267,6 @@ public class HistoryRepositoryImpl implements HistoryRepository {
         Map<String, String> nameValuePairs = new HashMap<>();
         nameValuePairs.put("ignore_unavailable", Boolean.toString(indicesOptions.ignoreUnavailable()));
         nameValuePairs.put("allow_no_indices", Boolean.toString(indicesOptions.allowNoIndices()));
-        nameValuePairs.put("ignore_throttled", Boolean.toString(indicesOptions.ignoreThrottled()));
         String expandWildcards;
         if (!indicesOptions.expandWildcardsOpen() && !indicesOptions.expandWildcardsClosed()) {
             expandWildcards = "none";
@@ -293,24 +292,20 @@ public class HistoryRepositoryImpl implements HistoryRepository {
         private static final IndexOptions LENIENT_EXPAND_OPEN = new IndexOptions(
                 true,
                 true,
-                false,
                 true,
                 false);
 
         private final boolean ignoreUnavailable;
         private final boolean allowNoIndices;
-        private final boolean ignoreThrottled;
         private final boolean expandWildcardsOpen;
         private final boolean expandWildcardsClosed;
 
         public IndexOptions(boolean ignoreUnavailable,
                             boolean allowNoIndices,
-                            boolean ignoreThrottled,
                             boolean expandWildcardsOpen,
                             boolean expandWildcardsClosed) {
             this.ignoreUnavailable = ignoreUnavailable;
             this.allowNoIndices = allowNoIndices;
-            this.ignoreThrottled = ignoreThrottled;
             this.expandWildcardsOpen = expandWildcardsOpen;
             this.expandWildcardsClosed = expandWildcardsClosed;
         }
@@ -325,10 +320,6 @@ public class HistoryRepositoryImpl implements HistoryRepository {
 
         public boolean allowNoIndices() {
             return allowNoIndices;
-        }
-
-        public boolean ignoreThrottled() {
-            return ignoreThrottled;
         }
 
         public boolean expandWildcardsOpen() {

--- a/elasticsearch-evolution-core/src/test/java/com/senacor/elasticsearch/evolution/core/internal/migration/execution/MigrationServiceImplIT.java
+++ b/elasticsearch-evolution-core/src/test/java/com/senacor/elasticsearch/evolution/core/internal/migration/execution/MigrationServiceImplIT.java
@@ -80,9 +80,9 @@ class MigrationServiceImplIT {
                 softly.assertThat(res.isLocked())
                         .isTrue();
                 softly.assertThat(res.getExecutionRuntimeInMillis())
-                        .isBetween(1, 6000);
+                        .isBetween(1, 8000);
                 softly.assertThat(res.getExecutionTimestamp())
-                        .isBetween(afterExecution.minus(6000, ChronoUnit.MILLIS), afterExecution);
+                        .isBetween(afterExecution.minus(8000, ChronoUnit.MILLIS), afterExecution);
             });
 
             // wait until all documents are indexed

--- a/elasticsearch-evolution-core/src/test/java/com/senacor/elasticsearch/evolution/core/test/EmbeddedElasticsearchExtension.java
+++ b/elasticsearch-evolution-core/src/test/java/com/senacor/elasticsearch/evolution/core/test/EmbeddedElasticsearchExtension.java
@@ -47,7 +47,7 @@ public class EmbeddedElasticsearchExtension implements TestInstancePostProcessor
             ofOpensearch("2.11.0"),
             ofOpensearch("2.10.0"),
             ofOpensearch("2.9.0"),
-            ofOpensearch("1.3.12"),
+            ofOpensearch("1.3.13"),
 
             ofElasticsearch("8.11.1"),
             ofElasticsearch("8.10.4"),

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>2.7.17</version>
+        <version>2.7.18</version>
     </parent>
 
     <name>elasticsearch-evolution</name>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -38,6 +38,7 @@
             <modules>
                 <module>test-spring-boot-3.0-scriptsInJarFile</module>
                 <module>test-spring-boot-3.1</module>
+                <module>test-spring-boot-3.2</module>
             </modules>
         </profile>
     </profiles>

--- a/tests/test-spring-boot-2.7/pom.xml
+++ b/tests/test-spring-boot-2.7/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.7.17</version>
+		<version>2.7.18</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.senacor.elasticsearch.evolution</groupId>

--- a/tests/test-spring-boot-3.2/pom.xml
+++ b/tests/test-spring-boot-3.2/pom.xml
@@ -5,11 +5,11 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.1.6</version>
+		<version>3.2.0</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.senacor.elasticsearch.evolution</groupId>
-	<artifactId>test-spring-boot-3.1</artifactId>
+	<artifactId>test-spring-boot-3.2</artifactId>
 	<version>0.5.1-SNAPSHOT</version>
 	<description>Demo project for Spring Boot</description>
 

--- a/tests/test-spring-boot-3.2/src/main/java/com/senacor/elasticsearch/evolution/springboot32/Application.java
+++ b/tests/test-spring-boot-3.2/src/main/java/com/senacor/elasticsearch/evolution/springboot32/Application.java
@@ -1,0 +1,14 @@
+package com.senacor.elasticsearch.evolution.springboot32;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+
+
+}

--- a/tests/test-spring-boot-3.2/src/main/resources/es/migration/V001.00__createTemplateWithIndexMapping.http
+++ b/tests/test-spring-boot-3.2/src/main/resources/es/migration/V001.00__createTemplateWithIndexMapping.http
@@ -1,0 +1,35 @@
+PUT _template/test_1
+Content-Type: application/json
+
+{
+  "index_patterns" : [
+    "test_*"
+  ],
+  "order" : 1,
+  "version" : 1,
+  "settings" : {
+    "number_of_shards" : 1
+  },
+  "mappings" : {
+    "dynamic" : "strict",
+    "properties" : {
+      "doc" : {
+        "dynamic" : false,
+        "properties" : {}
+      },
+      "searchable" : {
+        "dynamic" : false,
+        "properties" : {
+          "version" : {
+            "type" : "keyword",
+            "ignore_above" : 20,
+            "similarity" : "boolean"
+          },
+          "locked" : {
+            "type" : "boolean"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/test-spring-boot-3.2/src/main/resources/es/migration/V001.01__addDocument.http
+++ b/tests/test-spring-boot-3.2/src/main/resources/es/migration/V001.01__addDocument.http
@@ -1,0 +1,17 @@
+PUT /test_1/_doc/1?refresh
+Content-Type: application/json
+
+{
+  "searchable": {
+    "version": "1",
+    "locked": false
+  },
+  "doc": {
+    "version": "1",
+    "locked": false,
+    "success": true,
+    "a": "a a a",
+    "b": true,
+    "c": "c"
+  }
+}

--- a/tests/test-spring-boot-3.2/src/test/java/com/senacor/elasticsearch/evolution/springboot32/ApplicationTests.java
+++ b/tests/test-spring-boot-3.2/src/test/java/com/senacor/elasticsearch/evolution/springboot32/ApplicationTests.java
@@ -1,0 +1,66 @@
+package com.senacor.elasticsearch.evolution.springboot32;
+
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import org.apache.http.HttpHost;
+import org.elasticsearch.client.RestClient;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(properties = {"spring.elasticsearch.uris=http://localhost:" + ApplicationTests.ELASTICSEARCH_PORT})
+class ApplicationTests {
+
+    static final int ELASTICSEARCH_PORT = 18773;
+
+    @Autowired
+    private EsUtils esUtils;
+
+    @Test
+    void contextLoads() {
+        esUtils.refreshIndices();
+
+        List<String> documents = esUtils.fetchAllDocuments("test_1");
+
+        assertThat(documents).hasSize(1);
+    }
+
+    @TestConfiguration
+    static class Config {
+        @Bean(destroyMethod = "stop")
+        public ElasticsearchContainer elasticsearchContainer(@Value("${elasticsearch.version:7.5.2}") String esVersion) {
+            ElasticsearchContainer container = new ElasticsearchContainer(DockerImageName
+                    .parse("docker.elastic.co/elasticsearch/elasticsearch")
+                    .withTag(esVersion)) {
+                @Override
+                protected void containerIsStarted(InspectContainerResponse containerInfo) {
+                    // since testcontainers 1.17 it detects if ES 8.x is running and copies a certificate in this case
+                    // but we don't want security
+                }
+            }
+                    .withEnv("ES_JAVA_OPTS", "-Xms128m -Xmx128m")
+                    // since elasticsearch 8 security / https is enabled per default - but for testing it should be disabled
+                    .withEnv("xpack.security.enabled", "false")
+                    .withEnv("cluster.routing.allocation.disk.watermark.low", "97%")
+                    .withEnv("cluster.routing.allocation.disk.watermark.high", "98%")
+                    .withEnv("cluster.routing.allocation.disk.watermark.flood_stage", "99%");
+            container.setPortBindings(Collections.singletonList(ELASTICSEARCH_PORT + ":9200"));
+            container.start();
+            return container;
+        }
+
+        @Bean
+        public EsUtils esUtils(ElasticsearchContainer elasticsearchContainer) {
+            return new EsUtils(RestClient.builder(HttpHost.create(elasticsearchContainer.getHttpHostAddress())).build());
+        }
+    }
+}

--- a/tests/test-spring-boot-3.2/src/test/java/com/senacor/elasticsearch/evolution/springboot32/EsUtils.java
+++ b/tests/test-spring-boot-3.2/src/test/java/com/senacor/elasticsearch/evolution/springboot32/EsUtils.java
@@ -1,0 +1,72 @@
+package com.senacor.elasticsearch.evolution.springboot32;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.io.IOUtils;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.RestClient;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+/**
+ * @author Andreas Keefer
+ */
+public class EsUtils {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private final RestClient restClient;
+
+    public EsUtils(RestClient restClient) {
+        this.restClient = restClient;
+    }
+
+    public void refreshIndices() {
+        try {
+            restClient.performRequest(new Request("GET", "/_refresh"));
+        } catch (IOException e) {
+            throw new IllegalStateException("refreshIndices failed", e);
+        }
+    }
+
+    public List<String> fetchAllDocuments(String index) {
+        try {
+            Request post = new Request("POST", "/" + index + "/_search");
+            post.setJsonEntity("{" +
+                    "    \"query\": {" +
+                    "        \"match_all\": {}" +
+                    "    }" +
+                    "}");
+            Response response = restClient.performRequest(post);
+            int statusCode = response.getStatusLine().getStatusCode();
+            if (statusCode < 200 || statusCode >= 300) {
+                throw new IllegalStateException("fetchAllDocuments(" + index + ") failed with HTTP status " +
+                        statusCode + ": " + response.toString());
+            }
+            String body = IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
+
+            return parseDocuments(body)
+                    .collect(Collectors.toList());
+        } catch (IOException e) {
+            throw new IllegalStateException("fetchAllDocuments(" + index + ") failed", e);
+        }
+    }
+
+    private Stream<String> parseDocuments(String body) {
+        try {
+            JsonNode jsonNode = OBJECT_MAPPER.readTree(body);
+            return StreamSupport.stream(jsonNode.get("hits").get("hits").spliterator(), false)
+                    .map(hitNode -> hitNode.get("_source"))
+                    .map(JsonNode::toString);
+        } catch (IOException e) {
+            throw new IllegalStateException("parseDocuments failed. body=" + body, e);
+        }
+    }
+}
+


### PR DESCRIPTION
- version updates (spring-boot 2.7.18)
- added regression tests for spring boot 3.2
- remove deprecated query parameter `ignore_throttled` from ES requests