### PR TITLE
(fix): bean name collision

### DIFF
--- a/spring-boot-starter-elasticsearch-evolution/src/main/java/com/senacor/elasticsearch/evolution/spring/boot/starter/autoconfigure/ElasticsearchEvolutionAutoConfiguration.java
+++ b/spring-boot-starter-elasticsearch-evolution/src/main/java/com/senacor/elasticsearch/evolution/spring/boot/starter/autoconfigure/ElasticsearchEvolutionAutoConfiguration.java
@@ -94,7 +94,7 @@ public class ElasticsearchEvolutionAutoConfiguration {
         @Bean
         @ConditionalOnBean(RestClientBuilder.class)
         @ConditionalOnMissingBean
-        public RestClient restClient(RestClientBuilder restClientBuilder) {
+        public RestClient elasticRestClient(RestClientBuilder restClientBuilder) {
             logger.info("creating RestClient from {}", restClientBuilder);
             return restClientBuilder.build();
         }


### PR DESCRIPTION
(fix): bean name collision with the [`restClient`](https://github.com/Diffblue-benchmarks/Spring-projects-spring-boot/blob/b7d349db83c65ac7124666799ab8aae372322e48/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/elasticsearch/rest/RestClientAutoConfiguration.java#L53) from Spring Boot's `RestClientAutoConfiguration`