### PR TITLE
Use POST for requests with a body

### DIFF
--- a/elasticsearch-evolution-core/src/main/java/com/senacor/elasticsearch/evolution/core/internal/migration/execution/HistoryRepositoryImpl.java
+++ b/elasticsearch-evolution-core/src/main/java/com/senacor/elasticsearch/evolution/core/internal/migration/execution/HistoryRepositoryImpl.java
@@ -116,7 +116,7 @@ public class HistoryRepositoryImpl implements HistoryRepository {
     }
 
     private long executeCountRequest(Optional<String> countQuery) throws IOException {
-        final Request countRequest = new Request("GET", "/" + historyIndex + "/_count");
+        final Request countRequest = new Request("POST", "/" + historyIndex + "/_count");
         countRequest.addParameters(indicesOptions(IndexOptions.lenientExpandOpen()));
         countQuery.ifPresent(countRequest::setJsonEntity);
         final Response countResponse = restClient.performRequest(countRequest);


### PR DESCRIPTION
HTTP GET requests should not have a request body in order to be compatible with f.e Apache HttpClient.

To be compatible with OpenSearch, we currently exclude the `elasticsearch-rest-client` dependency and create our own implementation of the `org.elasticsearch.client.RestClient`.
This implementation delegates the requests to the OpenSearch Java Client.
We have configured our OpenSearch Java Client to work with the Apache HttpClient. And this fails now with the GET request with a body.

```
implementation ('com.senacor.elasticsearch.evolution:elasticsearch-evolution-core:0.6.0') {
        exclude group: 'org.elasticsearch.client', module: 'elasticsearch-rest-client'
}
```

```
package org.elasticsearch.client;
...

public class RestClient {

  private final org.opensearch.client.opensearch.OpenSearchClient javaClient;

  public RestClient(org.opensearch.client.opensearch.OpenSearchClient javaClient) {
    this.javaClient = javaClient;
  }

  public List<Node> getNodes() {
    return Collections.emptyList();
  }

  public Response performRequest(Request request) throws IOException {
    org.opensearch.client.opensearch.generic.Response execute =
        javaClient.generic().execute(request.getRequest());
    return new Response(execute);
  }
}
```

We are looking forward to the abstraction of the http client you are working on, since this will allow us to integrate with OpenSearch in a less hacky way.
Also for this solution to be compatible with all http clients there should be no GET requests with a request body.
https://github.com/senacor/elasticsearch-evolution/issues/198#issuecomment-3587412492