### PR TITLE
Added option to just validate without executing migrations (fixes #435)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,27 @@ ElasticsearchEvolution elasticsearchEvolution = ElasticsearchEvolution.configure
 elasticsearchEvolution.migrate();
 ```
 
+#### 3.2.1 Validation without execution
+
+If you just want to validate your migration scripts without executing them, you can use the `validate()` method:
+
+```java
+ElasticsearchEvolution elasticsearchEvolution = ...;
+// just validate the migrations
+elasticsearchEvolution.validate();
+```
+
+This will validate applied migrations against resolved ones (on the filesystem or classpath) to detect accidental
+changes that may prevent the schema(s) from being recreated exactly.
+
+Validation fails if:
+
+* a previously applied migration has been modified after it was applied (if enabled in configuration, see
+  `validateOnMigrate`)
+* versions have been resolved that haven't been applied yet
+
+Then a `ValidateException` is thrown.
+
 ## 4 Migration script format
 
 ### 4.1 Migration script file content
@@ -290,6 +311,7 @@ ElasticsearchEvolution.configure()
 - Added regression tests for spring boot 3.4.
 - Added regression tests against ElasticSearch 9.0 - 9.2
 - Added regression tests against OpenSearch 3.3 and 3.4
+- Added option to just validate without executing migrations ([#435](https://github.com/senacor/elasticsearch-evolution/issues/435)).
 
 ### v0.6.1
 

--- a/elasticsearch-evolution-core/src/main/java/com/senacor/elasticsearch/evolution/core/api/ValidateException.java
+++ b/elasticsearch-evolution-core/src/main/java/com/senacor/elasticsearch/evolution/core/api/ValidateException.java
@@ -1,0 +1,24 @@
+package com.senacor.elasticsearch.evolution.core.api;
+
+import com.senacor.elasticsearch.evolution.core.internal.model.FileNameInfo;
+import lombok.NonNull;
+
+import java.util.List;
+
+/**
+ * Exception thrown when Elasticsearch Evolution encounters a problem in the validate step.
+ */
+public class ValidateException extends IllegalStateException {
+
+    public ValidateException(@NonNull List<FileNameInfo> pendingScriptsToBeExecuted) {
+        this("There are pending migrations to be executed: " + pendingScriptsToBeExecuted);
+    }
+
+    public ValidateException(String message) {
+        super(message);
+    }
+
+    public ValidateException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/elasticsearch-evolution-core/src/main/java/com/senacor/elasticsearch/evolution/core/api/migration/MigrationService.java
+++ b/elasticsearch-evolution-core/src/main/java/com/senacor/elasticsearch/evolution/core/api/migration/MigrationService.java
@@ -3,6 +3,7 @@ package com.senacor.elasticsearch.evolution.core.api.migration;
 import com.senacor.elasticsearch.evolution.core.api.MigrationException;
 import com.senacor.elasticsearch.evolution.core.internal.model.dbhistory.MigrationScriptProtocol;
 import com.senacor.elasticsearch.evolution.core.internal.model.migration.ParsedMigrationScript;
+import lombok.NonNull;
 
 import java.util.Collection;
 import java.util.List;
@@ -20,5 +21,18 @@ public interface MigrationService {
      * @return executed Scripts
      * @throws MigrationException if execution failed
      */
-    List<MigrationScriptProtocol> executePendingScripts(Collection<ParsedMigrationScript> migrationScripts) throws MigrationException;
+    @NonNull
+    List<MigrationScriptProtocol> executePendingScripts(@NonNull Collection<ParsedMigrationScript> migrationScripts) throws MigrationException;
+
+    /**
+     * This method returns only those scripts, which must be executed.
+     * Already executed scripts will be filtered out.
+     * The returned scripts must be executed in the returned order.
+     *
+     * @param migrationScripts all migration scripts that were potentially executed earlier.
+     * @return list of ordered scripts which must be executed
+     * @throws MigrationException if validateOnMigrate failed
+     */
+    @NonNull
+    List<ParsedMigrationScript> getPendingScriptsToBeExecuted(@NonNull Collection<ParsedMigrationScript> migrationScripts) throws MigrationException;
 }

--- a/elasticsearch-evolution-core/src/test/java/com/senacor/elasticsearch/evolution/core/ElasticsearchEvolutionTest.java
+++ b/elasticsearch-evolution-core/src/test/java/com/senacor/elasticsearch/evolution/core/ElasticsearchEvolutionTest.java
@@ -1,18 +1,25 @@
 package com.senacor.elasticsearch.evolution.core;
 
 import com.senacor.elasticsearch.evolution.core.api.MigrationException;
+import com.senacor.elasticsearch.evolution.core.api.ValidateException;
+import com.senacor.elasticsearch.evolution.core.api.config.ElasticsearchEvolutionConfig;
+import com.senacor.elasticsearch.evolution.core.api.migration.MigrationService;
+import com.senacor.elasticsearch.evolution.core.internal.model.MigrationVersion;
+import com.senacor.elasticsearch.evolution.core.internal.model.migration.FileNameInfoImpl;
+import com.senacor.elasticsearch.evolution.core.internal.model.migration.ParsedMigrationScript;
 import com.senacor.elasticsearch.evolution.core.test.MockitoExtension;
 import org.apache.http.HttpHost;
 import org.elasticsearch.client.Node;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 
-import java.io.IOException;
+import java.util.List;
 
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.*;
@@ -37,59 +44,161 @@ class ElasticsearchEvolutionTest {
                 .thenReturn(singletonList(new Node(HttpHost.create("http://localhost:9200"))));
     }
 
-    @Test
-    void migrate_historyMaxQuerySizeToLow() throws IOException {
-        String indexName = "es_evolution";
-        int historyMaxQuerySize = 6;
-        ElasticsearchEvolution underTest = ElasticsearchEvolution.configure()
-                .setLocations(singletonList("classpath:es/ElasticsearchEvolutionTest/migrate_OK"))
-                .setHistoryIndex(indexName)
-                .setHistoryMaxQuerySize(historyMaxQuerySize)
-                .load(restHighLevelClient.getLowLevelClient());
+    @Nested
+    class MigrateShould {
 
-        assertThatThrownBy(underTest::migrate)
-                .isInstanceOf(MigrationException.class)
-                .hasMessage("configured historyMaxQuerySize of '%s' is to low for the number of migration scripts of '%s'", historyMaxQuerySize, 8);
+        @Test
+        void throw_MigrationException_when_historyMaxQuerySizeTooLow() {
+            String indexName = "es_evolution";
+            int historyMaxQuerySize = 6;
+            ElasticsearchEvolution underTest = ElasticsearchEvolution.configure()
+                    .setLocations(singletonList("classpath:es/ElasticsearchEvolutionTest/migrate_OK"))
+                    .setHistoryIndex(indexName)
+                    .setHistoryMaxQuerySize(historyMaxQuerySize)
+                    .load(restHighLevelClient.getLowLevelClient());
 
-        InOrder order = inOrder(restHighLevelClient, restClient);
-        order.verify(restHighLevelClient, times(2)).getLowLevelClient();
-        order.verify(restClient).getNodes();
-        order.verifyNoMoreInteractions();
+            assertThatThrownBy(underTest::migrate)
+                    .isInstanceOf(MigrationException.class)
+                    .hasMessage("configured historyMaxQuerySize of '%s' is too low for the number of migration scripts of '%s'", historyMaxQuerySize, 8);
+
+            InOrder order = inOrder(restHighLevelClient, restClient);
+            order.verify(restHighLevelClient, times(2)).getLowLevelClient();
+            order.verify(restClient).getNodes();
+            order.verifyNoMoreInteractions();
+        }
+
+        @Test
+        void do_nothing_on_empty_location() {
+            ElasticsearchEvolution underTest = ElasticsearchEvolution.configure()
+                    .setLocations(singletonList("classpath:es/ElasticsearchEvolutionTest/empty_location"))
+                    .load(restHighLevelClient.getLowLevelClient());
+
+            assertThatCode(underTest::migrate)
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void do_nothing_on_non_existing_location() {
+            ElasticsearchEvolution underTest = ElasticsearchEvolution.configure()
+                    .setLocations(singletonList("classpath:es/ElasticsearchEvolutionTest/does_not_exist"))
+                    .load(restHighLevelClient.getLowLevelClient());
+
+            assertThatCode(underTest::migrate)
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void return_zero_when_elasticsearchEvolution_IsNotEnabled() {
+            int migrations = ElasticsearchEvolution.configure()
+                    .setEnabled(false)
+                    .load(restHighLevelClient.getLowLevelClient())
+                    .migrate();
+
+            assertThat(migrations).isZero();
+
+            InOrder order = inOrder(restHighLevelClient, restClient);
+            order.verify(restHighLevelClient, times(2)).getLowLevelClient();
+            order.verify(restClient).getNodes();
+            order.verifyNoMoreInteractions();
+        }
     }
 
-    @Test
-    void migrate_empty_location() {
-        ElasticsearchEvolution underTest = ElasticsearchEvolution.configure()
-                .setLocations(singletonList("classpath:es/ElasticsearchEvolutionTest/empty_location"))
-                .load(restHighLevelClient.getLowLevelClient());
+    @Nested
+    class ValidateShould {
 
-        assertThatCode(underTest::migrate)
-                .doesNotThrowAnyException();
+        @Test
+        void throw_ValidateException_when_historyMaxQuerySizeTooLow() {
+            String indexName = "es_evolution";
+            int historyMaxQuerySize = 6;
+            ElasticsearchEvolution underTest = ElasticsearchEvolution.configure()
+                    .setLocations(singletonList("classpath:es/ElasticsearchEvolutionTest/migrate_OK"))
+                    .setHistoryIndex(indexName)
+                    .setHistoryMaxQuerySize(historyMaxQuerySize)
+                    .load(restHighLevelClient.getLowLevelClient());
+
+            assertThatThrownBy(underTest::validate)
+                    .isInstanceOf(ValidateException.class)
+                    .hasMessage("configured historyMaxQuerySize of '%s' is too low for the number of migration scripts of '%s'", historyMaxQuerySize, 8);
+
+            InOrder order = inOrder(restHighLevelClient, restClient);
+            order.verify(restHighLevelClient, times(2)).getLowLevelClient();
+            order.verify(restClient).getNodes();
+            order.verifyNoMoreInteractions();
+        }
+
+        @Test
+        void beValid_on_empty_location() {
+            ElasticsearchEvolution underTest = ElasticsearchEvolution.configure()
+                    .setLocations(singletonList("classpath:es/ElasticsearchEvolutionTest/empty_location"))
+                    .load(restHighLevelClient.getLowLevelClient());
+
+            assertThatCode(underTest::validate)
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void beValid_on_non_existing_location() {
+            ElasticsearchEvolution underTest = ElasticsearchEvolution.configure()
+                    .setLocations(singletonList("classpath:es/ElasticsearchEvolutionTest/does_not_exist"))
+                    .load(restHighLevelClient.getLowLevelClient());
+
+            assertThatCode(underTest::validate)
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void isValid_when_elasticsearchEvolution_IsNotEnabled() {
+            final ElasticsearchEvolution underTest = ElasticsearchEvolution.configure()
+                    .setEnabled(false)
+                    .load(restHighLevelClient.getLowLevelClient());
+
+            assertThatCode(underTest::validate)
+                    .doesNotThrowAnyException();
+
+            InOrder order = inOrder(restHighLevelClient, restClient);
+            order.verify(restHighLevelClient, times(2)).getLowLevelClient();
+            order.verify(restClient).getNodes();
+            order.verifyNoMoreInteractions();
+        }
+
+        @Test
+        void fail_when_pending_migrations_exist(@Mock MigrationService migrationService) {
+            final ElasticsearchEvolutionConfig config = ElasticsearchEvolution.configure();
+            final ElasticsearchEvolution underTest = new ElasticsearchEvolution(config, restClient) {
+                @Override
+                protected MigrationService createMigrationService() {
+                    return migrationService;
+                }
+            };
+            final ParsedMigrationScript pendingMigration = new ParsedMigrationScript();
+            pendingMigration.setFileNameInfo(new FileNameInfoImpl(MigrationVersion.fromVersion("1.0"), "des", "scriptName"));
+            when(migrationService.getPendingScriptsToBeExecuted(anyCollection()))
+                    .thenReturn(List.of(pendingMigration));
+
+            assertThatThrownBy(underTest::validate)
+                    .isInstanceOf(ValidateException.class)
+                    .hasMessage("There are pending migrations to be executed: [FileNameInfoImpl{version=1, description='des', scriptName='scriptName'}]");
+        }
+
+        @Test
+        void fail_when_MigrationService_throws_MigrationException(@Mock MigrationService migrationService) {
+            final ElasticsearchEvolutionConfig config = ElasticsearchEvolution.configure();
+            final ElasticsearchEvolution underTest = new ElasticsearchEvolution(config, restClient) {
+                @Override
+                protected MigrationService createMigrationService() {
+                    return migrationService;
+                }
+            };
+            final ParsedMigrationScript pendingMigration = new ParsedMigrationScript();
+            pendingMigration.setFileNameInfo(new FileNameInfoImpl(MigrationVersion.fromVersion("1.0"), "des", "scriptName"));
+            when(migrationService.getPendingScriptsToBeExecuted(anyCollection()))
+                    .thenThrow(new MigrationException("MigrationService failure"));
+
+            assertThatThrownBy(underTest::validate)
+                    .isInstanceOf(ValidateException.class)
+                    .hasMessage("Validation failed: MigrationService failure")
+                    .hasCauseInstanceOf(MigrationException.class)
+                    .hasRootCauseMessage("MigrationService failure");
+        }
     }
-
-    @Test
-    void migrate_non_existing_location() {
-        ElasticsearchEvolution underTest = ElasticsearchEvolution.configure()
-                .setLocations(singletonList("classpath:es/ElasticsearchEvolutionTest/does_not_exist"))
-                .load(restHighLevelClient.getLowLevelClient());
-
-        assertThatCode(underTest::migrate)
-                .doesNotThrowAnyException();
-    }
-
-    @Test
-    void elasticsearchEvolutionIsNotEnabled() {
-        int migrations = ElasticsearchEvolution.configure()
-                .setEnabled(false)
-                .load(restHighLevelClient.getLowLevelClient())
-                .migrate();
-
-        assertThat(migrations).isZero();
-
-        InOrder order = inOrder(restHighLevelClient, restClient);
-        order.verify(restHighLevelClient, times(2)).getLowLevelClient();
-        order.verify(restClient).getNodes();
-        order.verifyNoMoreInteractions();
-    }
-
 }


### PR DESCRIPTION
closes #435