### PR TITLE
`EvolutionOpenSearchRestClient` (`elasticsearch-evolution-rest-abstraction-os-restclient`) is now compatible with OpenSearch 2.x client libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Successfully executed migration scripts will not be executed again!
 - runs on Spring-Boot 3.x (and of course without Spring-Boot)
 - runs on Elasticsearch version 7.5.x - 9.x
   - but focussing on maintained versions, see [elastic.co/support/eol](https://www.elastic.co/support/eol) or [endoflife.date/elasticsearch](https://endoflife.date/elasticsearch)
-- runs on OpenSearch version 1.x - 3.x
+- runs on OpenSearch version 2.x - 3.x
   - but focussing on maintained versions, see [opensearch.org/releases](https://opensearch.org/releases/) or [endoflife.date/opensearch](https://endoflife.date/opensearch)
 - highly configurable (e.g. location(s) of your migration files, migration file format patterns)
 - placeholder substitution in migration scripts
@@ -35,7 +35,7 @@ Successfully executed migration scripts will not be executed again!
 
 | Compatibility                    | Spring Boot                                      | Elasticsearch        | OpenSearch |
 |----------------------------------|--------------------------------------------------|----------------------|------------|
-| elasticsearch-evolution >= 0.7.0 | 3.2 - 3.5                                        | 7.5.x - 9.x          | 1.x - 3.x  |
+| elasticsearch-evolution >= 0.7.0 | 3.2 - 3.5                                        | 7.5.x - 9.x          | 2.x - 3.x  |
 | elasticsearch-evolution >= 0.6.1 | 3.0 - 3.2                                        | 7.5.x - 8.19.x       | 1.x - 2.x  |
 | elasticsearch-evolution >= 0.4.2 | 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 3.0, 3.1, 3.2 | 7.5.x - 8.13.x       | 1.x - 2.x  |
 | elasticsearch-evolution >= 0.4.0 | 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7                | 7.5.x - 8.6.x        | 1.x - 2.x  |
@@ -388,7 +388,7 @@ ElasticsearchEvolution.configure()
 
 ### v0.7.3-SNAPSHOT
 
-- ...
+- fixed `EvolutionOpenSearchRestClient` (`elasticsearch-evolution-rest-abstraction-os-restclient`) compatibility with OpenSearch 2.x client libs ([#565](https://github.com/senacor/elasticsearch-evolution/issues/565))
 
 ### v0.7.2
 

--- a/elasticsearch-evolution-rest-abstraction-os-restclient/src/main/java/com/senacor/elasticsearch/evolution/rest/abstracion/os/restclient/EvolutionOpenSearchRestClient.java
+++ b/elasticsearch-evolution-rest-abstraction-os-restclient/src/main/java/com/senacor/elasticsearch/evolution/rest/abstracion/os/restclient/EvolutionOpenSearchRestClient.java
@@ -6,11 +6,10 @@ import com.senacor.elasticsearch.evolution.rest.abstracion.EvolutionRestResponse
 import com.senacor.elasticsearch.evolution.rest.abstracion.HttpMethod;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-import org.apache.hc.core5.http.ContentType;
-import org.apache.hc.core5.http.HttpEntity;
-import org.apache.hc.core5.http.ParseException;
-import org.apache.hc.core5.http.io.entity.EntityUtils;
-import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.apache.http.HttpEntity;
+import org.apache.http.entity.ContentType;
+import org.apache.http.nio.entity.NStringEntity;
+import org.apache.http.util.EntityUtils;
 import org.opensearch.client.Request;
 import org.opensearch.client.RequestOptions;
 import org.opensearch.client.Response;
@@ -46,7 +45,7 @@ public class EvolutionOpenSearchRestClient implements EvolutionRestClient {
             ContentType contentType = getContentType(headers)
                     .map(ContentType::parse)
                     .orElse(null);
-            request.setEntity(new StringEntity(body, contentType));
+            request.setEntity(new NStringEntity(body, contentType));
         }
         if (null != headers) {
             RequestOptions.Builder builder = RequestOptions.DEFAULT.toBuilder();
@@ -57,14 +56,9 @@ public class EvolutionOpenSearchRestClient implements EvolutionRestClient {
         final Response response = restClient.performRequest(request);
 
         final HttpEntity entity = response.getEntity();
-        final Optional<String> responseBody;
-        try {
-            responseBody = null == entity
-                    ? Optional.empty()
-                    : Optional.ofNullable(EntityUtils.toString(entity));
-        } catch (ParseException e) {
-            throw new IOException("header elements cannot be parsed", e);
-        }
+        Optional<String> responseBody = null == entity
+                ? Optional.empty()
+                : Optional.ofNullable(EntityUtils.toString(entity));
         return new EvolutionRestResponseImpl(response.getStatusLine().getStatusCode(),
                 Optional.ofNullable(response.getStatusLine().getReasonPhrase()),
                 responseBody);

--- a/elasticsearch-evolution-rest-abstraction-os-restclient/src/test/java/com/senacor/elasticsearch/evolution/rest/abstracion/os/restclient/EvolutionOpenSearchRestClientTest.java
+++ b/elasticsearch-evolution-rest-abstraction-os-restclient/src/test/java/com/senacor/elasticsearch/evolution/rest/abstracion/os/restclient/EvolutionOpenSearchRestClientTest.java
@@ -2,11 +2,11 @@ package com.senacor.elasticsearch.evolution.rest.abstracion.os.restclient;
 
 import com.senacor.elasticsearch.evolution.rest.abstracion.EvolutionRestResponse;
 import com.senacor.elasticsearch.evolution.rest.abstracion.HttpMethod;
-import org.apache.hc.core5.http.ContentType;
-import org.apache.hc.core5.http.HttpHost;
-import org.apache.hc.core5.http.ParseException;
-import org.apache.hc.core5.http.io.entity.EntityUtils;
-import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.apache.http.HttpHost;
+import org.apache.http.ParseException;
+import org.apache.http.entity.ContentType;
+import org.apache.http.nio.entity.NStringEntity;
+import org.apache.http.util.EntityUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -19,7 +19,6 @@ import org.opensearch.client.Response;
 import org.opensearch.client.RestClient;
 
 import java.io.IOException;
-import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Map;
 
@@ -44,7 +43,7 @@ class EvolutionOpenSearchRestClientTest {
     }
 
     @Test
-    void info() throws URISyntaxException {
+    void info() {
         when(restClient.getNodes())
                 .thenReturn(List.of(new Node(HttpHost.create("http://localhost:9200"))));
 
@@ -61,7 +60,7 @@ class EvolutionOpenSearchRestClientTest {
         when(response.getStatusLine().getReasonPhrase())
                 .thenReturn("OK");
         when(response.getEntity())
-                .thenReturn(new StringEntity("my body", ContentType.TEXT_PLAIN));
+                .thenReturn(new NStringEntity("my body", ContentType.TEXT_PLAIN));
 
 
         final EvolutionRestResponse res = underTest.execute(HttpMethod.POST,

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,8 @@
         <commons-io.version>2.21.0</commons-io.version>
         <!--when updating elasticsearch versions, also update "ElasticsearchContainer" version in EmbeddedElasticsearchExtension-->
         <elasticsearch.version>7.5.2</elasticsearch.version>
-        <opensearch-client.version>3.4.0</opensearch-client.version>
+        <opensearch-java.version>3.4.0</opensearch-java.version>
+        <opensearch-rest-client.version>2.19.4</opensearch-rest-client.version>
         <classgraph.version>4.8.184</classgraph.version>
         <testcontainers.elasticsearch.version>1.21.4</testcontainers.elasticsearch.version>
         <lombok.version>1.18.42</lombok.version>
@@ -167,12 +168,12 @@
             <dependency>
                 <groupId>org.opensearch.client</groupId>
                 <artifactId>opensearch-rest-client</artifactId>
-                <version>${opensearch-client.version}</version>
+                <version>${opensearch-rest-client.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.opensearch.client</groupId>
                 <artifactId>opensearch-java</artifactId>
-                <version>${opensearch-client.version}</version>
+                <version>${opensearch-java.version}</version>
             </dependency>
 
             <dependency>

--- a/spring-boot-starter-elasticsearch-evolution/src/main/java/com/senacor/elasticsearch/evolution/spring/boot/starter/autoconfigure/ElasticsearchEvolutionAutoConfiguration.java
+++ b/spring-boot-starter-elasticsearch-evolution/src/main/java/com/senacor/elasticsearch/evolution/spring/boot/starter/autoconfigure/ElasticsearchEvolutionAutoConfiguration.java
@@ -132,15 +132,9 @@ public class ElasticsearchEvolutionAutoConfiguration {
 
             logger.info("creating OpenSearch RestClientBuilder with uris {}", urisList);
 
-            org.apache.hc.core5.http.HttpHost[] httpHosts = urisList.stream()
-                    .map(opensearchUri -> {
-                        try {
-                            return org.apache.hc.core5.http.HttpHost.create(opensearchUri);
-                        } catch (URISyntaxException e) {
-                            throw new IllegalArgumentException("OpenSearch uri '%s' is invalid".formatted(opensearchUri), e);
-                        }
-                    })
-                    .toArray(org.apache.hc.core5.http.HttpHost[]::new);
+            HttpHost[] httpHosts = urisList.stream()
+                    .map(HttpHost::create)
+                    .toArray(HttpHost[]::new);
             return org.opensearch.client.RestClient.builder(httpHosts);
         }
 


### PR DESCRIPTION
fixes #565

`EvolutionOpenSearchRestClient` (`elasticsearch-evolution-rest-abstraction-os-restclient`) is now compatible with OpenSearch 2.x client libs. 

We use now `org.opensearch.client:opensearch-rest-client:2.19.4` dependency in `elasticsearch-evolution-rest-abstraction-os-restclient`