### PR TITLE
#565: added spring boot 4 compatibility

### DIFF
--- a/.github/workflows/maven-matrix.yml
+++ b/.github/workflows/maven-matrix.yml
@@ -68,11 +68,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Set up JDK 25
+      - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
           distribution: zulu
-          java-version: 25
+          java-version: 21
       - name: Build and test with Maven
         run: $MVN_CMD install -DskipTests
       - name: opensearch test version ${{ matrix.opensearchVersion }}
@@ -88,11 +88,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Set up JDK 25
+      - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
           distribution: zulu
-          java-version: 25
+          java-version: 21
       - name: Build and test with Maven
         run: $MVN_CMD install -DskipTests
       - name: opensearch test version ${{ matrix.opensearchVersion }}
@@ -213,5 +213,6 @@ jobs:
             elasticsearch-evolution-core/target/elasticsearch-evolution-core-${{ env.PROJECT_VERSION }}.jar
             elasticsearch-evolution-rest-abstraction/target/elasticsearch-evolution-rest-abstraction-${{ env.PROJECT_VERSION }}.jar
             elasticsearch-evolution-rest-abstraction-es-client/target/elasticsearch-evolution-rest-abstraction-es-client-${{ env.PROJECT_VERSION }}.jar
+            elasticsearch-evolution-rest-abstraction-es-rest5client/target/elasticsearch-evolution-rest-abstraction-es-rest5client-${{ env.PROJECT_VERSION }}.jar
             elasticsearch-evolution-rest-abstraction-os-genericclient/target/elasticsearch-evolution-rest-abstraction-os-genericclient-${{ env.PROJECT_VERSION }}.jar
             elasticsearch-evolution-rest-abstraction-os-restclient/target/elasticsearch-evolution-rest-abstraction-os-restclient-${{ env.PROJECT_VERSION }}.jar

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Successfully executed migration scripts will not be executed again!
 ## 2 Features
 
 - tested on Java 17, 21 and 25
-- runs on Spring-Boot 3.x (and of course without Spring-Boot)
+- runs on Spring-Boot 3.x and 4.x (and of course without Spring-Boot)
 - runs on Elasticsearch version 7.5.x - 9.x
   - but focussing on maintained versions, see [elastic.co/support/eol](https://www.elastic.co/support/eol) or [endoflife.date/elasticsearch](https://endoflife.date/elasticsearch)
 - runs on OpenSearch version 2.x - 3.x
@@ -35,6 +35,7 @@ Successfully executed migration scripts will not be executed again!
 
 | Compatibility                    | Spring Boot                                      | Elasticsearch        | OpenSearch |
 |----------------------------------|--------------------------------------------------|----------------------|------------|
+| elasticsearch-evolution >= 0.7.3 | 3.2 - 4.0                                        | 7.5.x - 9.x          | 2.x - 3.x  |
 | elasticsearch-evolution >= 0.7.0 | 3.2 - 3.5                                        | 7.5.x - 9.x          | 2.x - 3.x  |
 | elasticsearch-evolution >= 0.6.1 | 3.0 - 3.2                                        | 7.5.x - 8.19.x       | 1.x - 2.x  |
 | elasticsearch-evolution >= 0.4.2 | 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 3.0, 3.1, 3.2 | 7.5.x - 8.13.x       | 1.x - 2.x  |
@@ -131,6 +132,14 @@ Elasticsearch-Evolution uses a REST client abstraction (`EvolutionRestClient`). 
     <version>0.7.2</version>
   </dependency>
   ```
+* Elasticsearch [Rest5Client](https://central.sonatype.com/artifact/co.elastic.clients/elasticsearch-rest5-client) implementation: `EvolutionESRest5Client`
+  ```xml
+  <dependency>
+    <groupId>com.senacor.elasticsearch.evolution</groupId>
+    <artifactId>elasticsearch-evolution-rest-abstraction-es-rest5client</artifactId>
+    <version>0.7.3</version>
+  </dependency>
+  ```  
 * OpenSearch [RestClient](https://central.sonatype.com/artifact/org.opensearch.client/opensearch-rest-client) implementation: `EvolutionOpenSearchRestClient` which is designed for OpenSearch `2.x` because the `RestClientTransport` is deprecated for removal since `3.x`.
   ```xml
   <dependency>
@@ -284,8 +293,8 @@ spring.elasticsearch.evolution.historyIndex=es_evolution
 
 #### 5.1.1 Elasticsearch AutoConfiguration (since Spring Boot 2.1)
 
-Since Spring Boot 2.1, AutoConfiguration for Elasticsearch's REST client is provided (see `org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestClientAutoConfiguration`).
-You can configure the `RestClient`, required for Elasticsearch-Evolution, just like this in your `application.properties`:
+Since Spring Boot 2.1, AutoConfiguration for Elasticsearch's REST client is provided (see `org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestClientAutoConfiguration` or `org.springframework.boot.elasticsearch.autoconfigure.ElasticsearchRestClientAutoConfiguration` for Spring Boot 4).
+You can configure the client, required for Elasticsearch-Evolution, just like this in your `application.properties`:
 
 ```properties
 spring.elasticsearch.uris[0]=https://example.com:9200
@@ -293,9 +302,25 @@ spring.elasticsearch.username=my-user-name
 spring.elasticsearch.password=my-secret-pw
 ```
 
-#### 5.1.2 Customize Elasticsearch-Evolutions AutoConfiguration
+#### 5.1.2 OpenSearch AutoConfiguration
 
-##### 5.1.2.1 Custom Elasticsearch RestClient
+Elasticsearch-Evolution tries to be compatible with [spring-data-opensearch-starter](https://github.com/opensearch-project/spring-data-opensearch) and its AutoConfiguration.
+
+AutoConfiguration for OpenSearch's REST client is provided (see `org.opensearch.spring.boot.autoconfigure.OpenSearchRestClientAutoConfiguration`).
+
+AutoConfiguration for OpenSearch's java client is provided (see `org.opensearch.spring.boot.autoconfigure.OpenSearchClientAutoConfiguration`).
+
+You can configure the client, required for Elasticsearch-Evolution, just like this in your `application.properties`:
+
+```properties
+opensearch.uris[0]=https://example.com:9200
+opensearch.username=my-user-name
+opensearch.password=my-secret-pw
+```
+
+#### 5.1.3 Customize Elasticsearch-Evolutions AutoConfiguration
+
+##### 5.1.3.1 Custom Elasticsearch RestClient
 
 Elasticsearch-Evolution just needs an `EvolutionRestClient` as a Spring bean. The Elasticsearch `EvolutionESRestClient` implementation needs a `RestClient` Spring bean.
 If you don't have Spring Boot 2.1 or later, or you need a special `RestClient` configuration (e.g., to accept self-signed certificates or disable hostname validation), you can provide a custom `RestClient` like this:
@@ -322,12 +347,12 @@ public RestClient myRestClient() {
 }
 ```
 
-##### 5.1.2.2 Custom OpenSearch RestClient
+##### 5.1.3.2 Custom OpenSearch RestClient
 
 Elasticsearch-Evolution just needs an `EvolutionRestClient` as a Spring bean. The OpenSearch `EvolutionOpenSearchRestClient` implementation needs a `RestClient` Spring bean.
 If you don't use already the [spring-data-opensearch-starter](https://central.sonatype.com/artifact/org.opensearch.client/spring-data-opensearch-starter) or you need a special `RestClient` configuration (e.g., to accept self-signed certificates or disable hostname validation), you can provide a custom `RestClient` similar to the Elasticsearch example above.
 
-##### 5.1.2.3 Custom OpenSearchGenericClient
+##### 5.1.3.3 Custom OpenSearchGenericClient
 
 Elasticsearch-Evolution just needs an `EvolutionRestClient` as a Spring bean. The OpenSearch `EvolutionOpenSearchGenericClient` implementation needs a `OpenSearchGenericClient` or `OpenSearchClient` Spring bean.
 If you don't use already the [spring-data-opensearch-starter](https://central.sonatype.com/artifact/org.opensearch.client/spring-data-opensearch-starter) or you need a special `OpenSearch*Client` configuration (e.g., to accept self-signed certificates or disable hostname validation), you can provide a custom `OpenSearchGenericClient` or `OpenSearchClient` as Spring bean like this:
@@ -356,7 +381,7 @@ public OpenSearchTransport myOpenSearchTransport() throws URISyntaxException {
 }
 ```
 
-##### 5.1.2.4 Custom ElasticsearchEvolutionInitializer
+##### 5.1.3.4 Custom ElasticsearchEvolutionInitializer
 
 If you want to provide a customized initializer for Elasticsearch-Evolution (e.g., with a different order):
 
@@ -389,6 +414,8 @@ ElasticsearchEvolution.configure()
 ### v0.7.3-SNAPSHOT
 
 - fixed `EvolutionOpenSearchRestClient` (`elasticsearch-evolution-rest-abstraction-os-restclient`) compatibility with OpenSearch 2.x client libs ([#565](https://github.com/senacor/elasticsearch-evolution/issues/565))
+- added Spring Boot 4 compatibility [#564](https://github.com/senacor/elasticsearch-evolution/issues/564)
+  - Added Elasticsearch `EvolutionRestClient` implementation: `EvolutionESRest5Client`. It uses the [Apache HttpClient 5](https://hc.apache.org/) based `Rest5Client` from `co.elastic.clients:elasticsearch-rest5-client`
 
 ### v0.7.2
 

--- a/elasticsearch-evolution-core/pom.xml
+++ b/elasticsearch-evolution-core/pom.xml
@@ -80,7 +80,7 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>elasticsearch</artifactId>
+            <artifactId>testcontainers-elasticsearch</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/elasticsearch-evolution-rest-abstraction-es-rest5client/lombok.config
+++ b/elasticsearch-evolution-rest-abstraction-es-rest5client/lombok.config
@@ -1,0 +1,4 @@
+config.stopBubbling = true
+lombok.addLombokGeneratedAnnotation = true
+#required to deserialize a @Value @Builder annotated class with jackson without any other configuration
+lombok.anyConstructor.addConstructorProperties = true

--- a/elasticsearch-evolution-rest-abstraction-es-rest5client/pom.xml
+++ b/elasticsearch-evolution-rest-abstraction-es-rest5client/pom.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.senacor.elasticsearch.evolution</groupId>
+        <artifactId>elasticsearch-evolution-parent</artifactId>
+        <version>0.7.3-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+    <artifactId>elasticsearch-evolution-rest-abstraction-es-rest5client</artifactId>
+    <packaging>jar</packaging>
+
+    <name>${project.artifactId}</name>
+    <description>Impl of REST client abstraction with elasticsearch-rest5-client</description>
+    <url>https://github.com/senacor/elasticsearch-evolution</url>
+
+    <scm>
+        <connection>scm:git@github.com:senacor/elasticsearch-evolution.git</connection>
+        <developerConnection>scm:git@github.com:senacor/elasticsearch-evolution.git</developerConnection>
+        <url>https://github.com/senacor/elasticsearch-evolution</url>
+    </scm>
+
+    <properties>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>elasticsearch-evolution-rest-abstraction</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>co.elastic.clients</groupId>
+            <artifactId>elasticsearch-rest5-client</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Assertions -->
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <!-- support JDK 21 -->
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${project.groupId}.rest.abstraction.es.rest5client</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <failIfNoTests>true</failIfNoTests>
+                </configuration>
+            </plugin>
+        </plugins>
+
+    </build>
+
+</project>

--- a/elasticsearch-evolution-rest-abstraction-es-rest5client/src/main/java/com/senacor/elasticsearch/evolution/rest/abstracion/rest5client/EvolutionESRest5Client.java
+++ b/elasticsearch-evolution-rest-abstraction-es-rest5client/src/main/java/com/senacor/elasticsearch/evolution/rest/abstracion/rest5client/EvolutionESRest5Client.java
@@ -1,0 +1,72 @@
+package com.senacor.elasticsearch.evolution.rest.abstracion.rest5client;
+
+import co.elastic.clients.transport.rest5_client.low_level.Request;
+import co.elastic.clients.transport.rest5_client.low_level.RequestOptions;
+import co.elastic.clients.transport.rest5_client.low_level.Response;
+import co.elastic.clients.transport.rest5_client.low_level.Rest5Client;
+import com.senacor.elasticsearch.evolution.rest.abstracion.EvolutionRestClient;
+import com.senacor.elasticsearch.evolution.rest.abstracion.EvolutionRestResponse;
+import com.senacor.elasticsearch.evolution.rest.abstracion.EvolutionRestResponseImpl;
+import com.senacor.elasticsearch.evolution.rest.abstracion.HttpMethod;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.ParseException;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+public class EvolutionESRest5Client implements EvolutionRestClient {
+
+    @NonNull
+    private final Rest5Client restClient;
+
+    @Override
+    public String info() {
+        return "%s (nodes=%s)".formatted(EvolutionRestClient.super.info(), restClient.getNodes());
+    }
+
+    @Override
+    public EvolutionRestResponse execute(@NonNull HttpMethod method,
+                                         @NonNull String endpoint,
+                                         Map<String, String> headers,
+                                         Map<String, String> urlParams,
+                                         String body) throws IOException {
+        final Request request = new Request(method.name(), endpoint);
+        if (null != urlParams) {
+            request.addParameters(urlParams);
+        }
+        if (null != body
+                && !body.trim().isEmpty()) {
+            ContentType contentType = getContentType(headers)
+                    .map(ContentType::parse)
+                    .orElse(null);
+            request.setEntity(new StringEntity(body, contentType));
+        }
+        if (null != headers) {
+            RequestOptions.Builder builder = RequestOptions.DEFAULT.toBuilder();
+            headers.forEach(builder::addHeader);
+            request.setOptions(builder);
+        }
+
+        final Response response = restClient.performRequest(request);
+
+        final HttpEntity entity = response.getEntity();
+        final Optional<String> responseBody;
+        try {
+            responseBody = null == entity
+                    ? Optional.empty()
+                    : Optional.ofNullable(EntityUtils.toString(entity));
+        } catch (ParseException e) {
+            throw new IOException("failed to parse body content", e);
+        }
+        return new EvolutionRestResponseImpl(response.getStatusCode(),
+                Optional.empty(),
+                responseBody);
+    }
+}

--- a/elasticsearch-evolution-rest-abstraction-es-rest5client/src/test/java/com/senacor/elasticsearch/evolution/rest/abstracion/rest5client/EvolutionESRest5ClientTest.java
+++ b/elasticsearch-evolution-rest-abstraction-es-rest5client/src/test/java/com/senacor/elasticsearch/evolution/rest/abstracion/rest5client/EvolutionESRest5ClientTest.java
@@ -1,0 +1,173 @@
+package com.senacor.elasticsearch.evolution.rest.abstracion.rest5client;
+
+import co.elastic.clients.transport.rest5_client.low_level.Node;
+import co.elastic.clients.transport.rest5_client.low_level.Response;
+import co.elastic.clients.transport.rest5_client.low_level.Rest5Client;
+import com.senacor.elasticsearch.evolution.rest.abstracion.EvolutionRestResponse;
+import com.senacor.elasticsearch.evolution.rest.abstracion.HttpMethod;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.ParseException;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class EvolutionESRest5ClientTest {
+
+    @Mock
+    private Rest5Client restClient;
+
+    private EvolutionESRest5Client underTest;
+
+    @BeforeEach
+    void setUp() {
+        underTest = new EvolutionESRest5Client(restClient);
+    }
+
+    @Test
+    void info() throws URISyntaxException {
+        when(restClient.getNodes())
+                .thenReturn(List.of(new Node(HttpHost.create("http://localhost:9200"))));
+
+        assertThat(underTest.info())
+                .isEqualTo(underTest.getClass().getName() + " (nodes=[[host=http://localhost:9200]])");
+    }
+
+    @Test
+    void execute_should_call_ESRestClient_withFullResponse(@Mock(answer = Answers.RETURNS_DEEP_STUBS) Response response) throws IOException {
+        when(restClient.performRequest(any()))
+                .thenReturn(response);
+        when(response.getStatusCode())
+                .thenReturn(200);
+        when(response.getEntity())
+                .thenReturn(new StringEntity("my body", ContentType.TEXT_PLAIN));
+
+
+        final EvolutionRestResponse res = underTest.execute(HttpMethod.POST,
+                "/_search",
+                Map.of("Content-Type", "application/json"),
+                Map.of("refresh", "true"),
+                """
+                        {"query": "bar"}""");
+
+
+        assertThat(res)
+                .as("response")
+                .isNotNull();
+        assertThat(res.statusCode())
+                .as("status code")
+                .isEqualTo(200);
+        assertThat(res.statusReasonPhrase())
+                .as("status reason phrase")
+                .isEmpty();
+        assertThat(res.body())
+                .as("body")
+                .contains("my body");
+
+        final InOrder order = inOrder(restClient);
+        order.verify(restClient).performRequest(argThat(argument -> {
+            assertSoftly(softly -> {
+                softly.assertThat(argument.getMethod())
+                        .as("HTTP method")
+                        .isEqualTo("POST");
+                softly.assertThat(argument.getEndpoint())
+                        .as("endpoint")
+                        .isEqualTo("/_search");
+                softly.assertThat(argument.getParameters())
+                        .as("URL parameters")
+                        .containsExactlyInAnyOrderEntriesOf(Map.of("refresh", "true"));
+                softly.assertThat(argument.getOptions().getHeaders())
+                        .as("headers")
+                        .anySatisfy(header -> {
+                            softly.assertThat(header.getName())
+                                    .as("header name")
+                                    .isEqualTo("Content-Type");
+                            softly.assertThat(header.getValue())
+                                    .as("header value")
+                                    .isEqualTo("application/json");
+                        });
+                try {
+                    String body = EntityUtils.toString(argument.getEntity());
+                    softly.assertThat(body)
+                            .as("body")
+                            .isEqualTo("""
+                                    {"query": "bar"}""");
+                } catch (IOException | ParseException e) {
+                    softly.fail("failed to validate body", e);
+                }
+            });
+            return true;
+        }));
+        order.verifyNoMoreInteractions();
+    }
+
+    @Test
+    void execute_should_call_ESRestClient_withMinimumResponse(@Mock(answer = Answers.RETURNS_DEEP_STUBS) Response response) throws IOException {
+        when(restClient.performRequest(any()))
+                .thenReturn(response);
+        when(response.getStatusCode())
+                .thenReturn(200);
+        when(response.getEntity())
+                .thenReturn(null);
+
+
+        final EvolutionRestResponse res = underTest.execute(HttpMethod.POST,
+                "/_search");
+
+
+        assertThat(res)
+                .as("response")
+                .isNotNull();
+        assertThat(res.statusCode())
+                .as("status code")
+                .isEqualTo(200);
+        assertThat(res.statusReasonPhrase())
+                .as("status reason phrase")
+                .isEmpty();
+        assertThat(res.body())
+                .as("body")
+                .isEmpty();
+
+        final InOrder order = inOrder(restClient);
+        order.verify(restClient).performRequest(argThat(argument -> {
+            assertSoftly(softly -> {
+                softly.assertThat(argument.getMethod())
+                        .as("HTTP method")
+                        .isEqualTo("POST");
+                softly.assertThat(argument.getEndpoint())
+                        .as("endpoint")
+                        .isEqualTo("/_search");
+                softly.assertThat(argument.getParameters())
+                        .as("URL parameters")
+                        .isNullOrEmpty();
+                softly.assertThat(argument.getOptions().getHeaders())
+                        .as("headers")
+                        .isEmpty();
+                softly.assertThat(argument.getEntity())
+                            .as("body")
+                            .isNull();
+            });
+            return true;
+        }));
+        order.verifyNoMoreInteractions();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -108,10 +108,11 @@
         <commons-io.version>2.21.0</commons-io.version>
         <!--when updating elasticsearch versions, also update "ElasticsearchContainer" version in EmbeddedElasticsearchExtension-->
         <elasticsearch.version>7.5.2</elasticsearch.version>
+        <elasticsearch-rest5-client.version>9.2.4</elasticsearch-rest5-client.version>
         <opensearch-java.version>3.4.0</opensearch-java.version>
         <opensearch-rest-client.version>2.19.4</opensearch-rest-client.version>
         <classgraph.version>4.8.184</classgraph.version>
-        <testcontainers.elasticsearch.version>1.21.4</testcontainers.elasticsearch.version>
+        <testcontainers.elasticsearch.version>2.0.3</testcontainers.elasticsearch.version>
         <lombok.version>1.18.42</lombok.version>
     </properties>
 
@@ -158,8 +159,13 @@
                 </exclusions>
             </dependency>
             <dependency>
+                <groupId>co.elastic.clients</groupId>
+                <artifactId>elasticsearch-rest5-client</artifactId>
+                <version>${elasticsearch-rest5-client.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.testcontainers</groupId>
-                <artifactId>elasticsearch</artifactId>
+                <artifactId>testcontainers-elasticsearch</artifactId>
                 <version>${testcontainers.elasticsearch.version}</version>
                 <scope>test</scope>
             </dependency>
@@ -396,6 +402,7 @@
     <modules>
         <module>elasticsearch-evolution-rest-abstraction</module>
         <module>elasticsearch-evolution-rest-abstraction-es-client</module>
+        <module>elasticsearch-evolution-rest-abstraction-es-rest5client</module>
         <module>elasticsearch-evolution-rest-abstraction-os-restclient</module>
         <module>elasticsearch-evolution-rest-abstraction-os-genericclient</module>
         <module>elasticsearch-evolution-core</module>

--- a/spring-boot-starter-elasticsearch-evolution/pom.xml
+++ b/spring-boot-starter-elasticsearch-evolution/pom.xml
@@ -38,6 +38,12 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>elasticsearch-evolution-rest-abstraction-es-rest5client</artifactId>
+            <version>${project.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>elasticsearch-evolution-rest-abstraction-os-genericclient</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
@@ -111,7 +117,7 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>elasticsearch</artifactId>
+            <artifactId>testcontainers-elasticsearch</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/spring-boot-starter-elasticsearch-evolution/src/test/java/com/senacor/elasticsearch/evolution/spring/boot/starter/autoconfigure/ElasticsearchEvolutionAutoConfigurationAppContextRunnerTest.java
+++ b/spring-boot-starter-elasticsearch-evolution/src/test/java/com/senacor/elasticsearch/evolution/spring/boot/starter/autoconfigure/ElasticsearchEvolutionAutoConfigurationAppContextRunnerTest.java
@@ -1,11 +1,14 @@
 package com.senacor.elasticsearch.evolution.spring.boot.starter.autoconfigure;
 
+import co.elastic.clients.transport.rest5_client.low_level.Rest5Client;
+import co.elastic.clients.transport.rest5_client.low_level.Rest5ClientBuilder;
 import com.senacor.elasticsearch.evolution.core.ElasticsearchEvolution;
 import com.senacor.elasticsearch.evolution.core.api.config.ElasticsearchEvolutionConfig;
 import com.senacor.elasticsearch.evolution.rest.abstracion.EvolutionRestClient;
 import com.senacor.elasticsearch.evolution.rest.abstracion.esclient.EvolutionESRestClient;
 import com.senacor.elasticsearch.evolution.rest.abstracion.os.genericclient.EvolutionOpenSearchGenericClient;
 import com.senacor.elasticsearch.evolution.rest.abstracion.os.restclient.EvolutionOpenSearchRestClient;
+import com.senacor.elasticsearch.evolution.rest.abstracion.rest5client.EvolutionESRest5Client;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
 import org.junit.jupiter.api.Test;
@@ -82,7 +85,7 @@ class ElasticsearchEvolutionAutoConfigurationAppContextRunnerTest {
     @Test
     void whenEvolutionRestClientIsMissing_thenADefautOneIsCreatedAndAlsoElasticsearchEvolution() {
         contextRunner
-                .withClassLoader(new FilteredClassLoader(EvolutionOpenSearchGenericClient.class, EvolutionOpenSearchRestClient.class))
+                .withClassLoader(new FilteredClassLoader(EvolutionESRest5Client.class, EvolutionOpenSearchGenericClient.class, EvolutionOpenSearchRestClient.class))
                 .run(context -> {
                     assertThat(context).hasSingleBean(ElasticsearchEvolutionConfig.class)
                             .hasSingleBean(RestClient.class)
@@ -93,7 +96,7 @@ class ElasticsearchEvolutionAutoConfigurationAppContextRunnerTest {
     @Test
     void whenElasticsearchRestClientExists_thenEvolutionESRestClientIsCreated() {
         contextRunner
-                .withClassLoader(new FilteredClassLoader(EvolutionOpenSearchGenericClient.class, EvolutionOpenSearchRestClient.class))
+                .withClassLoader(new FilteredClassLoader(EvolutionESRest5Client.class, EvolutionOpenSearchGenericClient.class, EvolutionOpenSearchRestClient.class))
                 .withUserConfiguration(ElasticsearchRestClientConfig.class)
                 .run(context -> {
                     assertThat(context).hasSingleBean(RestClient.class)
@@ -106,7 +109,7 @@ class ElasticsearchEvolutionAutoConfigurationAppContextRunnerTest {
     @Test
     void whenElasticsearchRestClientBuilderExists_thenRestClientIsCreated() {
         contextRunner
-                .withClassLoader(new FilteredClassLoader(EvolutionOpenSearchGenericClient.class, EvolutionOpenSearchRestClient.class))
+                .withClassLoader(new FilteredClassLoader(EvolutionESRest5Client.class, EvolutionOpenSearchGenericClient.class, EvolutionOpenSearchRestClient.class))
                 .withUserConfiguration(ElasticsearchRestClientBuilderConfig.class)
                 .run(context -> {
                     assertThat(context).hasSingleBean(RestClientBuilder.class)
@@ -120,7 +123,7 @@ class ElasticsearchEvolutionAutoConfigurationAppContextRunnerTest {
     @Test
     void whenNoElasticsearchRestClientOrBuilderExists_andUrisAreProvided_thenDefaultRestClientIsCreated() {
         contextRunner
-                .withClassLoader(new FilteredClassLoader(EvolutionOpenSearchGenericClient.class, EvolutionOpenSearchRestClient.class))
+                .withClassLoader(new FilteredClassLoader(EvolutionESRest5Client.class, EvolutionOpenSearchGenericClient.class, EvolutionOpenSearchRestClient.class))
                 .withPropertyValues("spring.elasticsearch.uris=http://localhost:9200,http://localhost:9201")
                 .run(context -> {
                     assertThat(context).hasSingleBean(RestClientBuilder.class)
@@ -134,7 +137,7 @@ class ElasticsearchEvolutionAutoConfigurationAppContextRunnerTest {
     @Test
     void whenCustomEvolutionRestClientExists_thenDefaultEvolutionESRestClientIsNotCreated() {
         contextRunner
-                .withClassLoader(new FilteredClassLoader(EvolutionOpenSearchGenericClient.class, EvolutionOpenSearchRestClient.class))
+                .withClassLoader(new FilteredClassLoader(EvolutionESRest5Client.class, EvolutionOpenSearchGenericClient.class, EvolutionOpenSearchRestClient.class))
                 .withUserConfiguration(CustomEvolutionRestClientConfig.class)
                 .run(context -> {
                     assertThat(context).hasSingleBean(EvolutionRestClient.class)
@@ -145,12 +148,66 @@ class ElasticsearchEvolutionAutoConfigurationAppContextRunnerTest {
                 });
     }
 
+    // ========== Elasticsearch Rest5Client Configuration Tests ==========
+
+    @Test
+    void whenElasticsearchRest5ClientExists_thenEvolutionESRest5ClientIsCreated() {
+        contextRunner
+                .withClassLoader(new FilteredClassLoader(EvolutionESRestClient.class, EvolutionOpenSearchGenericClient.class, EvolutionOpenSearchRestClient.class))
+                .withUserConfiguration(ElasticsearchRest5ClientConfig.class)
+                .run(context -> {
+                    assertThat(context).hasSingleBean(Rest5Client.class)
+                            .hasSingleBean(EvolutionESRest5Client.class)
+                            .hasSingleBean(EvolutionRestClient.class)
+                            .hasSingleBean(ElasticsearchEvolution.class);
+                });
+    }
+
+    @Test
+    void whenElasticsearchRest5ClientBuilderExists_thenRest5ClientIsCreated() {
+        contextRunner
+                .withClassLoader(new FilteredClassLoader(EvolutionESRestClient.class, EvolutionOpenSearchGenericClient.class, EvolutionOpenSearchRestClient.class))
+                .withUserConfiguration(ElasticsearchRest5ClientBuilderConfig.class)
+                .run(context -> {
+                    assertThat(context).hasSingleBean(Rest5ClientBuilder.class)
+                            .hasSingleBean(Rest5Client.class)
+                            .hasSingleBean(EvolutionRestClient.class)
+                            .hasSingleBean(EvolutionESRest5Client.class)
+                            .hasSingleBean(ElasticsearchEvolution.class);
+                });
+    }
+
+    @Test
+    void whenNoElasticsearchRest5ClientOrBuilderExists_andUrisAreProvided_thenDefaultRest5ClientIsCreated() {
+        contextRunner
+                .withClassLoader(new FilteredClassLoader(EvolutionESRestClient.class, EvolutionOpenSearchGenericClient.class, EvolutionOpenSearchRestClient.class))
+                .withPropertyValues("spring.elasticsearch.uris=http://localhost:9200,http://localhost:9201")
+                .run(context -> {
+                    assertThat(context).hasSingleBean(Rest5ClientBuilder.class)
+                            .hasSingleBean(Rest5Client.class)
+                            .hasSingleBean(EvolutionRestClient.class)
+                            .hasSingleBean(EvolutionESRest5Client.class)
+                            .hasSingleBean(ElasticsearchEvolution.class);
+                });
+    }
+
+    @Test
+    void whenElasticsearchRest5ClientConfigurationIsDisabled_thenEvolutionESRest5ClientIsNotCreated() {
+        contextRunner
+                .withClassLoader(new FilteredClassLoader(EvolutionESRestClient.class, EvolutionOpenSearchGenericClient.class, EvolutionOpenSearchRestClient.class))
+                .withPropertyValues("spring.elasticsearch.evolution.es.rest5client.enabled=false")
+                .withUserConfiguration(ElasticsearchRest5ClientConfig.class)
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(EvolutionESRest5Client.class);
+                });
+    }
+
     // ========== OpenSearch RestClient Configuration Tests ==========
 
     @Test
     void whenOpenSearchRestClientExists_thenEvolutionOpenSearchRestClientIsCreated() {
         contextRunner
-                .withClassLoader(new FilteredClassLoader(EvolutionESRestClient.class, EvolutionOpenSearchGenericClient.class))
+                .withClassLoader(new FilteredClassLoader(EvolutionESRest5Client.class, EvolutionESRestClient.class, EvolutionOpenSearchGenericClient.class))
                 .withUserConfiguration(OpenSearchRestClientConfig.class)
                 .run(context -> {
                     assertThat(context).hasSingleBean(org.opensearch.client.RestClient.class)
@@ -163,7 +220,7 @@ class ElasticsearchEvolutionAutoConfigurationAppContextRunnerTest {
     @Test
     void whenOpenSearchRestClientBuilderExists_thenOpenSearchRestClientIsCreated() {
         contextRunner
-                .withClassLoader(new FilteredClassLoader(EvolutionOpenSearchGenericClient.class, EvolutionESRestClient.class))
+                .withClassLoader(new FilteredClassLoader(EvolutionESRest5Client.class, EvolutionOpenSearchGenericClient.class, EvolutionESRestClient.class))
                 .withUserConfiguration(OpenSearchRestClientBuilderConfig.class)
                 .run(context -> {
                     assertThat(context).hasSingleBean(org.opensearch.client.RestClientBuilder.class)
@@ -177,7 +234,7 @@ class ElasticsearchEvolutionAutoConfigurationAppContextRunnerTest {
     @Test
     void whenNoOpenSearchRestClientOrBuilderExists_andUrisAreProvided_thenDefaultOpenSearchRestClientIsCreated() {
         contextRunner
-                .withClassLoader(new FilteredClassLoader(EvolutionOpenSearchGenericClient.class, EvolutionESRestClient.class))
+                .withClassLoader(new FilteredClassLoader(EvolutionESRest5Client.class, EvolutionOpenSearchGenericClient.class, EvolutionESRestClient.class))
                 .withPropertyValues("opensearch.uris=http://localhost:9200,http://localhost:9201")
                 .run(context -> {
                     assertThat(context).hasSingleBean(org.opensearch.client.RestClientBuilder.class)
@@ -193,7 +250,7 @@ class ElasticsearchEvolutionAutoConfigurationAppContextRunnerTest {
     @Test
     void whenOpenSearchGenericClientExists_thenEvolutionOpenSearchGenericClientIsCreated() {
         contextRunner
-                .withClassLoader(new FilteredClassLoader(EvolutionESRestClient.class, EvolutionOpenSearchRestClient.class))
+                .withClassLoader(new FilteredClassLoader(EvolutionESRest5Client.class, EvolutionESRestClient.class, EvolutionOpenSearchRestClient.class))
                 .withUserConfiguration(OpenSearchGenericClientConfig.class)
                 .run(context -> {
                     assertThat(context).hasSingleBean(OpenSearchGenericClient.class)
@@ -206,7 +263,7 @@ class ElasticsearchEvolutionAutoConfigurationAppContextRunnerTest {
     @Test
     void whenOpenSearchClientExists_thenEvolutionOpenSearchGenericClientIsCreated() {
         contextRunner
-                .withClassLoader(new FilteredClassLoader(EvolutionESRestClient.class, EvolutionOpenSearchRestClient.class))
+                .withClassLoader(new FilteredClassLoader(EvolutionESRest5Client.class, EvolutionESRestClient.class, EvolutionOpenSearchRestClient.class))
                 .withUserConfiguration(OpenSearchClientConfig.class)
                 .run(context -> {
                     assertThat(context).hasSingleBean(OpenSearchClient.class)
@@ -219,7 +276,7 @@ class ElasticsearchEvolutionAutoConfigurationAppContextRunnerTest {
     @Test
     void whenOpenSearchTransportExists_thenOpenSearchGenericClientIsCreated() {
         contextRunner
-                .withClassLoader(new FilteredClassLoader(EvolutionESRestClient.class, EvolutionOpenSearchRestClient.class))
+                .withClassLoader(new FilteredClassLoader(EvolutionESRest5Client.class, EvolutionESRestClient.class, EvolutionOpenSearchRestClient.class))
                 .withUserConfiguration(OpenSearchTransportConfig.class)
                 .run(context -> {
                     assertThat(context).hasSingleBean(OpenSearchTransport.class)
@@ -233,7 +290,7 @@ class ElasticsearchEvolutionAutoConfigurationAppContextRunnerTest {
     @Test
     void whenNoOpenSearchClientExists_andUrisAreProvided_thenDefaultOpenSearchGenericClientIsCreated() {
         contextRunner
-                .withClassLoader(new FilteredClassLoader(EvolutionESRestClient.class, EvolutionOpenSearchRestClient.class))
+                .withClassLoader(new FilteredClassLoader(EvolutionESRest5Client.class, EvolutionESRestClient.class, EvolutionOpenSearchRestClient.class))
                 .withPropertyValues("opensearch.uris=http://localhost:9200")
                 .run(context -> {
                     assertThat(context).hasSingleBean(OpenSearchGenericClient.class)
@@ -299,6 +356,22 @@ class ElasticsearchEvolutionAutoConfigurationAppContextRunnerTest {
         @Bean
         public EvolutionRestClient evolutionRestClient() {
             return evolutionRestClient;
+        }
+    }
+
+    @Configuration
+    static class ElasticsearchRest5ClientConfig {
+        @Bean
+        public Rest5Client rest5Client() {
+            return mock(Rest5Client.class);
+        }
+    }
+
+    @Configuration
+    static class ElasticsearchRest5ClientBuilderConfig {
+        @Bean
+        public Rest5ClientBuilder rest5ClientBuilder() {
+            return mock(Rest5ClientBuilder.class, Mockito.RETURNS_DEEP_STUBS);
         }
     }
 

--- a/spring-boot-starter-elasticsearch-evolution/src/test/java/com/senacor/elasticsearch/evolution/spring/boot/starter/autoconfigure/ElasticsearchEvolutionAutoConfigurationIT.java
+++ b/spring-boot-starter-elasticsearch-evolution/src/test/java/com/senacor/elasticsearch/evolution/spring/boot/starter/autoconfigure/ElasticsearchEvolutionAutoConfigurationIT.java
@@ -26,7 +26,12 @@ import static org.springframework.test.annotation.DirtiesContext.ClassMode.BEFOR
  * @author Andreas Keefer
  */
 @ExtendWith(SpringExtension.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = {
+                "spring.elasticsearch.evolution.es.rest5client.enabled=false",
+                "spring.elasticsearch.evolution.os.restclient.enabled=false",
+                "spring.elasticsearch.evolution.os.genericclient.enabled=false",
+        })
 @ContextConfiguration(classes = {EmbeddedElasticsearchConfiguration.class, SpringBootTestApplication.class})
 @DirtiesContext(classMode = BEFORE_CLASS)
 class ElasticsearchEvolutionAutoConfigurationIT {
@@ -54,7 +59,8 @@ class ElasticsearchEvolutionAutoConfigurationIT {
 
         assertThat(searchResponse.getHits().getTotalHits().value)
                 .as("searchResponse: %s", searchResponse)
-                .isEqualTo(1);
+                .as("Documents created by migration files")
+                .isOne();
     }
 
 }

--- a/tests-elasticsearch/pom.xml
+++ b/tests-elasticsearch/pom.xml
@@ -23,5 +23,6 @@
         <module>test-es-spring-boot-3.3-scriptsInJarFile</module>
         <module>test-es-spring-boot-3.4-scriptsInJarFile</module>
         <module>test-es-spring-boot-3.5</module>
+        <module>test-es-spring-boot-4.0-scriptsInJarFile</module>
     </modules>
 </project>

--- a/tests-elasticsearch/test-es-spring-boot-3.2/pom.xml
+++ b/tests-elasticsearch/test-es-spring-boot-3.2/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.6</version>
+		<version>3.2.12</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.senacor.elasticsearch.evolution</groupId>
@@ -18,7 +18,7 @@
 
 		<commons-io.version>2.21.0</commons-io.version>
 		<elasticsearch.version>7.5.2</elasticsearch.version>
-		<testcontainers.elasticsearch.version>1.21.4</testcontainers.elasticsearch.version>
+		<testcontainers.elasticsearch.version>2.0.3</testcontainers.elasticsearch.version>
 	</properties>
 
 	<dependencies>
@@ -48,7 +48,7 @@
 		<!--Embedded Elasticsearch dependencies-->
 		<dependency>
 			<groupId>org.testcontainers</groupId>
-			<artifactId>elasticsearch</artifactId>
+			<artifactId>testcontainers-elasticsearch</artifactId>
 			<version>${testcontainers.elasticsearch.version}</version>
 			<scope>test</scope>
 		</dependency>
@@ -82,7 +82,6 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<!--jacoco snapshot to support java 17/18-->
 				<version>0.8.14</version>
 				<executions>
 					<execution>

--- a/tests-elasticsearch/test-es-spring-boot-3.3-scriptsInJarFile/pom.xml
+++ b/tests-elasticsearch/test-es-spring-boot-3.3-scriptsInJarFile/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.0</version>
+        <version>3.3.13</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.senacor.elasticsearch.evolution</groupId>
@@ -18,7 +18,7 @@
 
         <commons-io.version>2.21.0</commons-io.version>
         <elasticsearch.version>7.5.2</elasticsearch.version>
-        <testcontainers.elasticsearch.version>1.21.4</testcontainers.elasticsearch.version>
+        <testcontainers.elasticsearch.version>2.0.3</testcontainers.elasticsearch.version>
     </properties>
 
     <dependencies>
@@ -55,7 +55,7 @@
         <!--Embedded Elasticsearch dependencies-->
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>elasticsearch</artifactId>
+            <artifactId>testcontainers-elasticsearch</artifactId>
             <version>${testcontainers.elasticsearch.version}</version>
             <scope>test</scope>
         </dependency>
@@ -89,7 +89,6 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <!--jacoco snapshot to support java 17/18-->
                 <version>0.8.14</version>
                 <executions>
                     <execution>

--- a/tests-elasticsearch/test-es-spring-boot-3.4-scriptsInJarFile/pom.xml
+++ b/tests-elasticsearch/test-es-spring-boot-3.4-scriptsInJarFile/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.12</version>
+        <version>3.4.13</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.senacor.elasticsearch.evolution</groupId>
@@ -18,7 +18,7 @@
 
         <commons-io.version>2.21.0</commons-io.version>
         <elasticsearch.version>7.5.2</elasticsearch.version>
-        <testcontainers.elasticsearch.version>1.21.4</testcontainers.elasticsearch.version>
+        <testcontainers.elasticsearch.version>2.0.3</testcontainers.elasticsearch.version>
     </properties>
 
     <dependencies>
@@ -55,7 +55,7 @@
         <!--Embedded Elasticsearch dependencies-->
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>elasticsearch</artifactId>
+            <artifactId>testcontainers-elasticsearch</artifactId>
             <version>${testcontainers.elasticsearch.version}</version>
             <scope>test</scope>
         </dependency>
@@ -89,7 +89,6 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <!--jacoco snapshot to support java 17/18-->
                 <version>0.8.14</version>
                 <executions>
                     <execution>

--- a/tests-elasticsearch/test-es-spring-boot-3.5/pom.xml
+++ b/tests-elasticsearch/test-es-spring-boot-3.5/pom.xml
@@ -18,7 +18,7 @@
 
 		<commons-io.version>2.21.0</commons-io.version>
 		<elasticsearch.version>7.5.2</elasticsearch.version>
-		<testcontainers.elasticsearch.version>1.21.4</testcontainers.elasticsearch.version>
+		<testcontainers.elasticsearch.version>2.0.3</testcontainers.elasticsearch.version>
 	</properties>
 
 	<dependencies>
@@ -48,7 +48,7 @@
 		<!--Embedded Elasticsearch dependencies-->
 		<dependency>
 			<groupId>org.testcontainers</groupId>
-			<artifactId>elasticsearch</artifactId>
+			<artifactId>testcontainers-elasticsearch</artifactId>
 			<version>${testcontainers.elasticsearch.version}</version>
 			<scope>test</scope>
 		</dependency>
@@ -82,7 +82,6 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<!--jacoco snapshot to support java 17/18-->
 				<version>0.8.14</version>
 				<executions>
 					<execution>

--- a/tests-elasticsearch/test-es-spring-boot-4.0-scriptsInJarFile/pom.xml
+++ b/tests-elasticsearch/test-es-spring-boot-4.0-scriptsInJarFile/pom.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.0.1</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <groupId>com.senacor.elasticsearch.evolution</groupId>
+    <artifactId>test-es-spring-boot-4.0-scriptsInJarFile</artifactId>
+    <version>0.7.3-SNAPSHOT</version>
+    <description>Demo project for Spring Boot</description>
+
+    <properties>
+        <java.version>17</java.version>
+
+        <elasticsearch.version>7.5.2</elasticsearch.version>
+    </properties>
+
+    <dependencies>
+        <!-- migration files in jar -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>migration-scripts</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-elasticsearch</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!--Elasticsearch Evolution dependencies-->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>spring-boot-starter-elasticsearch-evolution</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>elasticsearch-evolution-rest-abstraction-es-rest5client</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!--Embedded Elasticsearch dependencies-->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-elasticsearch</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.14</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <failIfNoTests>true</failIfNoTests>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>4.9.8.2</version>
+                <configuration>
+                    <xmlOutput>true</xmlOutput>
+                    <failOnError>false</failOnError>
+                    <effort>max</effort>
+                    <threshold>high</threshold>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/tests-elasticsearch/test-es-spring-boot-4.0-scriptsInJarFile/src/main/java/com/senacor/elasticsearch/evolution/springboot40/Application.java
+++ b/tests-elasticsearch/test-es-spring-boot-4.0-scriptsInJarFile/src/main/java/com/senacor/elasticsearch/evolution/springboot40/Application.java
@@ -1,0 +1,13 @@
+package com.senacor.elasticsearch.evolution.springboot40;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+
+}

--- a/tests-elasticsearch/test-es-spring-boot-4.0-scriptsInJarFile/src/main/resources/application.properties
+++ b/tests-elasticsearch/test-es-spring-boot-4.0-scriptsInJarFile/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+spring.elasticsearch.evolution.locations[0]=classpath:es/mig
+spring.elasticsearch.evolution.placeholders.index=test_1

--- a/tests-elasticsearch/test-es-spring-boot-4.0-scriptsInJarFile/src/test/java/com/senacor/elasticsearch/evolution/springboot40/ApplicationTest.java
+++ b/tests-elasticsearch/test-es-spring-boot-4.0-scriptsInJarFile/src/test/java/com/senacor/elasticsearch/evolution/springboot40/ApplicationTest.java
@@ -1,0 +1,65 @@
+package com.senacor.elasticsearch.evolution.springboot40;
+
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.client.RestClient;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(properties = {"spring.elasticsearch.uris=http://localhost:" + ApplicationTest.ELASTICSEARCH_PORT})
+class ApplicationTest {
+
+    static final int ELASTICSEARCH_PORT = 18779;
+
+    @Autowired
+    private EsUtils esUtils;
+
+    @Test
+    void contextLoads() {
+        esUtils.refreshIndices();
+
+        List<String> documents = esUtils.fetchAllDocuments("test_1");
+
+        assertThat(documents).hasSize(1);
+    }
+
+    @TestConfiguration
+    static class Config {
+        @Bean(destroyMethod = "stop")
+        public ElasticsearchContainer elasticsearchContainer(@Value("${elasticsearch.version:7.5.2}") String esVersion) {
+            ElasticsearchContainer container = new ElasticsearchContainer(DockerImageName
+                    .parse("docker.elastic.co/elasticsearch/elasticsearch")
+                    .withTag(esVersion)) {
+                @Override
+                protected void containerIsStarted(InspectContainerResponse containerInfo) {
+                    // since testcontainers 1.17 it detects if ES 8.x is running and copies a certificate in this case
+                    // but we don't want security
+                }
+            }
+                    .withEnv("ES_JAVA_OPTS", "-Xms128m -Xmx128m")
+                    // since elasticsearch 8 security / https is enabled per default - but for testing it should be disabled
+                    .withEnv("xpack.security.enabled", "false")
+                    .withEnv("cluster.routing.allocation.disk.watermark.low", "97%")
+                    .withEnv("cluster.routing.allocation.disk.watermark.high", "98%")
+                    .withEnv("cluster.routing.allocation.disk.watermark.flood_stage", "99%");
+            container.setPortBindings(Collections.singletonList(ELASTICSEARCH_PORT + ":9200"));
+            container.start();
+            return container;
+        }
+
+        @Bean
+        public EsUtils esUtils(ElasticsearchContainer elasticsearchContainer) {
+            return new EsUtils(RestClient.create("http://" + elasticsearchContainer.getHttpHostAddress()));
+        }
+    }
+}

--- a/tests-elasticsearch/test-es-spring-boot-4.0-scriptsInJarFile/src/test/java/com/senacor/elasticsearch/evolution/springboot40/EsUtils.java
+++ b/tests-elasticsearch/test-es-spring-boot-4.0-scriptsInJarFile/src/test/java/com/senacor/elasticsearch/evolution/springboot40/EsUtils.java
@@ -1,0 +1,65 @@
+package com.senacor.elasticsearch.evolution.springboot40;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.io.IOUtils;
+import org.springframework.http.MediaType;
+import org.springframework.web.client.RestClient;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+/**
+ * @author Andreas Keefer
+ */
+public class EsUtils {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private final RestClient restClient;
+
+    public EsUtils(RestClient restClient) {
+        this.restClient = restClient;
+    }
+
+    public void refreshIndices() {
+        restClient.get().uri("/_refresh").retrieve();
+    }
+
+    public List<String> fetchAllDocuments(String index) {
+        String body = restClient.post()
+                .uri("/" + index + "/_search")
+                .body("""
+                        {\
+                            "query": {\
+                                "match_all": {}\
+                            }\
+                        }\
+                        """)
+                .contentType(MediaType.APPLICATION_JSON)
+                .retrieve()
+                .onStatus(status -> !status.is2xxSuccessful(), (request, response) -> {
+                    throw new IllegalStateException("fetchAllDocuments(" + index + ") failed with HTTP status " +
+                            response.getStatusCode().value() + ": " + IOUtils.toString(response.getBody(), StandardCharsets.UTF_8));
+                })
+                .body(String.class);
+
+        return parseDocuments(body)
+                .toList();
+    }
+
+    private Stream<String> parseDocuments(String body) {
+        try {
+            JsonNode jsonNode = OBJECT_MAPPER.readTree(body);
+            return StreamSupport.stream(jsonNode.get("hits").get("hits").spliterator(), false)
+                    .map(hitNode -> hitNode.get("_source"))
+                    .map(JsonNode::toString);
+        } catch (IOException e) {
+            throw new IllegalStateException("parseDocuments failed. body=" + body, e);
+        }
+    }
+}
+

--- a/tests-opensearch-genericclient/pom.xml
+++ b/tests-opensearch-genericclient/pom.xml
@@ -19,5 +19,6 @@
 
     <modules>
         <module>test-os-genericclient-spring-boot-3.5</module>
+        <module>test-os-genericclient-spring-boot-4.0</module>
     </modules>
 </project>

--- a/tests-opensearch-genericclient/test-os-genericclient-spring-boot-3.5/src/test/java/com/senacor/elasticsearch/evolution/springboot35/ApplicationTests.java
+++ b/tests-opensearch-genericclient/test-os-genericclient-spring-boot-3.5/src/test/java/com/senacor/elasticsearch/evolution/springboot35/ApplicationTests.java
@@ -35,7 +35,7 @@ class ApplicationTests {
     @TestConfiguration
     static class Config {
         @Bean(destroyMethod = "stop")
-        public OpenSearchContainer<?> elasticsearchContainer(@Value("${opensearch.version:2.19.4}") String osVersion) {
+        public OpenSearchContainer<?> opensearchContainer(@Value("${opensearch.version:2.19.4}") String osVersion) {
             OpenSearchContainer<?> container = new OpenSearchContainer<>(DockerImageName
                     .parse("quay.io/xtermi2/opensearch")
                     .asCompatibleSubstituteFor("opensearchproject/opensearch")

--- a/tests-opensearch-genericclient/test-os-genericclient-spring-boot-4.0/pom.xml
+++ b/tests-opensearch-genericclient/test-os-genericclient-spring-boot-4.0/pom.xml
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>4.0.1</version>
+		<relativePath/> <!-- lookup parent from repository -->
+	</parent>
+	<groupId>com.senacor.elasticsearch.evolution</groupId>
+	<artifactId>test-os-genericclient-spring-boot-4.0</artifactId>
+	<version>0.7.3-SNAPSHOT</version>
+	<description>Demo project for Spring Boot with OpenSearchGenericClient</description>
+
+	<properties>
+		<java.version>17</java.version>
+
+		<commons-io.version>2.21.0</commons-io.version>
+		<opensearch.version>2.19.4</opensearch.version>
+	</properties>
+
+	<dependencies>
+		<!-- migration files in jar -->
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>migration-scripts</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-webmvc</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.opensearch.client</groupId>
+			<artifactId>spring-data-opensearch-starter</artifactId>
+			<version>3.0.0</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.opensearch.client</groupId>
+					<artifactId>opensearch-rest-high-level-client</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<!--Elasticsearch Evolution dependencies-->
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>spring-boot-starter-elasticsearch-evolution</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>elasticsearch-evolution-rest-abstraction-os-genericclient</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<!--Embedded Opensearch dependencies-->
+		<dependency>
+			<groupId>org.opensearch</groupId>
+			<artifactId>opensearch-testcontainers</artifactId>
+			<version>4.1.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>${commons-io.version}</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<pluginRepositories>
+		<pluginRepository>
+			<id>oss.sonatype.org-snapshot</id>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</pluginRepository>
+	</pluginRepositories>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.14</version>
+				<executions>
+					<execution>
+						<id>prepare-agent</id>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>post-integration-test</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<failIfNoTests>true</failIfNoTests>
+				</configuration>
+			</plugin>
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>4.9.8.2</version>
+                <configuration>
+                    <xmlOutput>true</xmlOutput>
+                    <failOnError>false</failOnError>
+                    <effort>max</effort>
+                    <threshold>high</threshold>
+                </configuration>
+            </plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/tests-opensearch-genericclient/test-os-genericclient-spring-boot-4.0/src/main/java/com/senacor/elasticsearch/evolution/springboot40/Application.java
+++ b/tests-opensearch-genericclient/test-os-genericclient-spring-boot-4.0/src/main/java/com/senacor/elasticsearch/evolution/springboot40/Application.java
@@ -1,0 +1,12 @@
+package com.senacor.elasticsearch.evolution.springboot40;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+}

--- a/tests-opensearch-genericclient/test-os-genericclient-spring-boot-4.0/src/main/resources/application.properties
+++ b/tests-opensearch-genericclient/test-os-genericclient-spring-boot-4.0/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+spring.elasticsearch.evolution.locations[0]=classpath:es/mig
+spring.elasticsearch.evolution.placeholders.index=test_1

--- a/tests-opensearch-genericclient/test-os-genericclient-spring-boot-4.0/src/test/java/com/senacor/elasticsearch/evolution/springboot40/ApplicationTests.java
+++ b/tests-opensearch-genericclient/test-os-genericclient-spring-boot-4.0/src/test/java/com/senacor/elasticsearch/evolution/springboot40/ApplicationTests.java
@@ -1,0 +1,61 @@
+package com.senacor.elasticsearch.evolution.springboot40;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+import org.opensearch.testcontainers.OpenSearchContainer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.client.RestClient;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@SpringBootTest(properties = {"opensearch.uris=http://localhost:" + ApplicationTests.OPENSEARCH_PORT})
+@EnabledForJreRange(min = JRE.JAVA_21) // spring-data-opensearch-starter requires Java 21+
+class ApplicationTests {
+
+    static final int OPENSEARCH_PORT = 18778;
+
+    @Autowired
+    private EsUtils esUtils;
+
+    @Test
+    void contextLoads() {
+        esUtils.refreshIndices();
+
+        List<String> documents = esUtils.fetchAllDocuments("test_1");
+
+        assertThat(documents).hasSize(1);
+    }
+
+    @TestConfiguration
+    static class Config {
+        @Bean(destroyMethod = "stop")
+        public OpenSearchContainer<?> opensearchContainer(@Value("${opensearch.version:2.19.4}") String osVersion) {
+            OpenSearchContainer<?> container = new OpenSearchContainer<>(DockerImageName
+                    .parse("quay.io/xtermi2/opensearch")
+                    .asCompatibleSubstituteFor("opensearchproject/opensearch")
+                    .withTag(osVersion));
+            container.withEnv("OPENSEARCH_JAVA_OPTS", "-Xms196m -Xmx196m")
+                    .withEnv("DISABLE_INSTALL_DEMO_CONFIG", "true")
+                    .withEnv("cluster.routing.allocation.disk.watermark.low", "97%")
+                    .withEnv("cluster.routing.allocation.disk.watermark.high", "98%")
+                    .withEnv("cluster.routing.allocation.disk.watermark.flood_stage", "99%")
+                    .setPortBindings(List.of(OPENSEARCH_PORT + ":9200"));
+            container.start();
+            return container;
+        }
+
+        @Bean
+        public EsUtils esUtils(OpenSearchContainer<?> openSearchContainer) {
+            return new EsUtils(RestClient.create(openSearchContainer.getHttpHostAddress()));
+        }
+    }
+}

--- a/tests-opensearch-genericclient/test-os-genericclient-spring-boot-4.0/src/test/java/com/senacor/elasticsearch/evolution/springboot40/EsUtils.java
+++ b/tests-opensearch-genericclient/test-os-genericclient-spring-boot-4.0/src/test/java/com/senacor/elasticsearch/evolution/springboot40/EsUtils.java
@@ -1,0 +1,64 @@
+package com.senacor.elasticsearch.evolution.springboot40;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.io.IOUtils;
+import org.springframework.http.MediaType;
+import org.springframework.web.client.RestClient;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+/**
+ * @author Andreas Keefer
+ */
+public class EsUtils {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private final RestClient restClient;
+
+    public EsUtils(RestClient restClient) {
+        this.restClient = restClient;
+    }
+
+    public void refreshIndices() {
+        restClient.get().uri("/_refresh").retrieve();
+    }
+
+    public List<String> fetchAllDocuments(String index) {
+        String body = restClient.post()
+                .uri("/" + index + "/_search")
+                .body("""
+                        {\
+                            "query": {\
+                                "match_all": {}\
+                            }\
+                        }\
+                        """)
+                .contentType(MediaType.APPLICATION_JSON)
+                .retrieve()
+                .onStatus(status -> !status.is2xxSuccessful(), (request, response) -> {
+                    throw new IllegalStateException("fetchAllDocuments(" + index + ") failed with HTTP status " +
+                            response.getStatusCode().value() + ": " + IOUtils.toString(response.getBody(), StandardCharsets.UTF_8));
+                })
+                .body(String.class);
+
+        return parseDocuments(body)
+                .toList();
+    }
+
+    private Stream<String> parseDocuments(String body) {
+        try {
+            JsonNode jsonNode = OBJECT_MAPPER.readTree(body);
+            return StreamSupport.stream(jsonNode.get("hits").get("hits").spliterator(), false)
+                    .map(hitNode -> hitNode.get("_source"))
+                    .map(JsonNode::toString);
+        } catch (IOException e) {
+            throw new IllegalStateException("parseDocuments failed. body=" + body, e);
+        }
+    }
+}

--- a/tests-opensearch-restclient/pom.xml
+++ b/tests-opensearch-restclient/pom.xml
@@ -19,5 +19,6 @@
 
     <modules>
         <module>test-os-restclient-spring-boot-3.5</module>
+        <module>test-os-restclient-spring-boot-4.0</module>
     </modules>
 </project>

--- a/tests-opensearch-restclient/test-os-restclient-spring-boot-3.5/src/test/java/com/senacor/elasticsearch/evolution/springboot35/ApplicationTests.java
+++ b/tests-opensearch-restclient/test-os-restclient-spring-boot-3.5/src/test/java/com/senacor/elasticsearch/evolution/springboot35/ApplicationTests.java
@@ -35,7 +35,7 @@ class ApplicationTests {
     @TestConfiguration
     static class Config {
         @Bean(destroyMethod = "stop")
-        public OpenSearchContainer<?> elasticsearchContainer(@Value("${opensearch.version:2.19.4}") String osVersion) {
+        public OpenSearchContainer<?> opensearchContainer(@Value("${opensearch.version:2.19.4}") String osVersion) {
             OpenSearchContainer<?> container = new OpenSearchContainer<>(DockerImageName
                     .parse("quay.io/xtermi2/opensearch")
                     .asCompatibleSubstituteFor("opensearchproject/opensearch")

--- a/tests-opensearch-restclient/test-os-restclient-spring-boot-4.0/pom.xml
+++ b/tests-opensearch-restclient/test-os-restclient-spring-boot-4.0/pom.xml
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>4.0.1</version>
+		<relativePath/> <!-- lookup parent from repository -->
+	</parent>
+	<groupId>com.senacor.elasticsearch.evolution</groupId>
+	<artifactId>test-os-restclient-spring-boot-4.0</artifactId>
+	<version>0.7.3-SNAPSHOT</version>
+	<description>Demo project for Spring Boot with OpenSearch RestClient</description>
+
+	<properties>
+		<java.version>17</java.version>
+
+		<commons-io.version>2.21.0</commons-io.version>
+		<opensearch.version>2.19.4</opensearch.version>
+	</properties>
+
+	<dependencies>
+		<!-- migration files in jar -->
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>migration-scripts</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-webmvc</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<!--Elasticsearch Evolution dependencies-->
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>spring-boot-starter-elasticsearch-evolution</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>elasticsearch-evolution-rest-abstraction-os-restclient</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<!--Embedded Opensearch dependencies-->
+		<dependency>
+			<groupId>org.opensearch</groupId>
+			<artifactId>opensearch-testcontainers</artifactId>
+			<version>4.1.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>${commons-io.version}</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<pluginRepositories>
+		<pluginRepository>
+			<id>oss.sonatype.org-snapshot</id>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</pluginRepository>
+	</pluginRepositories>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.14</version>
+				<executions>
+					<execution>
+						<id>prepare-agent</id>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>post-integration-test</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<failIfNoTests>true</failIfNoTests>
+				</configuration>
+			</plugin>
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>4.9.8.2</version>
+                <configuration>
+                    <xmlOutput>true</xmlOutput>
+                    <failOnError>false</failOnError>
+                    <effort>max</effort>
+                    <threshold>high</threshold>
+                </configuration>
+            </plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/tests-opensearch-restclient/test-os-restclient-spring-boot-4.0/src/main/java/com/senacor/elasticsearch/evolution/springboot40/Application.java
+++ b/tests-opensearch-restclient/test-os-restclient-spring-boot-4.0/src/main/java/com/senacor/elasticsearch/evolution/springboot40/Application.java
@@ -1,0 +1,12 @@
+package com.senacor.elasticsearch.evolution.springboot40;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+}

--- a/tests-opensearch-restclient/test-os-restclient-spring-boot-4.0/src/main/resources/application.properties
+++ b/tests-opensearch-restclient/test-os-restclient-spring-boot-4.0/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+spring.elasticsearch.evolution.locations[0]=classpath:es/mig
+spring.elasticsearch.evolution.placeholders.index=test_1

--- a/tests-opensearch-restclient/test-os-restclient-spring-boot-4.0/src/test/java/com/senacor/elasticsearch/evolution/springboot40/ApplicationTests.java
+++ b/tests-opensearch-restclient/test-os-restclient-spring-boot-4.0/src/test/java/com/senacor/elasticsearch/evolution/springboot40/ApplicationTests.java
@@ -1,0 +1,58 @@
+package com.senacor.elasticsearch.evolution.springboot40;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.testcontainers.OpenSearchContainer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.client.RestClient;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@SpringBootTest(properties = {"opensearch.uris=http://localhost:" + ApplicationTests.OPENSEARCH_PORT})
+class ApplicationTests {
+
+    static final int OPENSEARCH_PORT = 18777;
+
+    @Autowired
+    private EsUtils esUtils;
+
+    @Test
+    void contextLoads() {
+        esUtils.refreshIndices();
+
+        List<String> documents = esUtils.fetchAllDocuments("test_1");
+
+        assertThat(documents).hasSize(1);
+    }
+
+    @TestConfiguration
+    static class Config {
+        @Bean(destroyMethod = "stop")
+        public OpenSearchContainer<?> opensearchContainer(@Value("${opensearch.version:2.19.4}") String osVersion) {
+            OpenSearchContainer<?> container = new OpenSearchContainer<>(DockerImageName
+                    .parse("quay.io/xtermi2/opensearch")
+                    .asCompatibleSubstituteFor("opensearchproject/opensearch")
+                    .withTag(osVersion));
+            container.withEnv("OPENSEARCH_JAVA_OPTS", "-Xms196m -Xmx196m")
+                    .withEnv("DISABLE_INSTALL_DEMO_CONFIG", "true")
+                    .withEnv("cluster.routing.allocation.disk.watermark.low", "97%")
+                    .withEnv("cluster.routing.allocation.disk.watermark.high", "98%")
+                    .withEnv("cluster.routing.allocation.disk.watermark.flood_stage", "99%")
+                    .setPortBindings(List.of(OPENSEARCH_PORT + ":9200"));
+            container.start();
+            return container;
+        }
+
+        @Bean
+        public EsUtils esUtils(OpenSearchContainer<?> openSearchContainer) {
+            return new EsUtils(RestClient.create(openSearchContainer.getHttpHostAddress()));
+        }
+    }
+}

--- a/tests-opensearch-restclient/test-os-restclient-spring-boot-4.0/src/test/java/com/senacor/elasticsearch/evolution/springboot40/EsUtils.java
+++ b/tests-opensearch-restclient/test-os-restclient-spring-boot-4.0/src/test/java/com/senacor/elasticsearch/evolution/springboot40/EsUtils.java
@@ -1,0 +1,64 @@
+package com.senacor.elasticsearch.evolution.springboot40;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.io.IOUtils;
+import org.springframework.http.MediaType;
+import org.springframework.web.client.RestClient;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+/**
+ * @author Andreas Keefer
+ */
+public class EsUtils {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private final RestClient restClient;
+
+    public EsUtils(RestClient restClient) {
+        this.restClient = restClient;
+    }
+
+    public void refreshIndices() {
+        restClient.get().uri("/_refresh").retrieve();
+    }
+
+    public List<String> fetchAllDocuments(String index) {
+        String body = restClient.post()
+                .uri("/" + index + "/_search")
+                .body("""
+                        {\
+                            "query": {\
+                                "match_all": {}\
+                            }\
+                        }\
+                        """)
+                .contentType(MediaType.APPLICATION_JSON)
+                .retrieve()
+                .onStatus(status -> !status.is2xxSuccessful(), (request, response) -> {
+                    throw new IllegalStateException("fetchAllDocuments(" + index + ") failed with HTTP status " +
+                            response.getStatusCode().value() + ": " + IOUtils.toString(response.getBody(), StandardCharsets.UTF_8));
+                })
+                .body(String.class);
+
+        return parseDocuments(body)
+                .toList();
+    }
+
+    private Stream<String> parseDocuments(String body) {
+        try {
+            JsonNode jsonNode = OBJECT_MAPPER.readTree(body);
+            return StreamSupport.stream(jsonNode.get("hits").get("hits").spliterator(), false)
+                    .map(hitNode -> hitNode.get("_source"))
+                    .map(JsonNode::toString);
+        } catch (IOException e) {
+            throw new IllegalStateException("parseDocuments failed. body=" + body, e);
+        }
+    }
+}


### PR DESCRIPTION
resolves #564

- added Spring Boot 4 compatibility [#564](https://github.com/senacor/elasticsearch-evolution/issues/564)
  - Added Elasticsearch `EvolutionRestClient` implementation: `EvolutionESRest5Client`. It uses the [Apache HttpClient 5](https://hc.apache.org/) based `Rest5Client` from `co.elastic.clients:elasticsearch-rest5-client`