### PR TITLE
Fix for Missing Override annotation

### DIFF
--- a/elasticsearch-evolution-core/src/main/java/com/senacor/elasticsearch/evolution/core/internal/model/MigrationVersion.java
+++ b/elasticsearch-evolution-core/src/main/java/com/senacor/elasticsearch/evolution/core/internal/model/MigrationVersion.java
@@ -163,6 +163,7 @@ public final class MigrationVersion implements Comparable<MigrationVersion> {
     }
 
     @SuppressWarnings("NullableProblems")
+    @Override
     public int compareTo(MigrationVersion o) {
         if (o == null) {
             return 1;


### PR DESCRIPTION
To fix the problem, we should explicitly mark the `compareTo` method as overriding the interface method by adding the `@Override` annotation directly above its declaration. This is the standard Java way to indicate that a method implements or overrides a method from a superclass or interface, and it enables the compiler to verify the override relationship.

Concretely, in `elasticsearch-evolution-core/src/main/java/com/senacor/elasticsearch/evolution/core/internal/model/MigrationVersion.java`, locate the `compareTo` method starting at line 166. Immediately above `public int compareTo(MigrationVersion o) {`, add the `@Override` annotation. No imports or additional methods are needed because `@Override` is part of `java.lang` and does not require an explicit import. This change does not alter any logic, only the annotation metadata.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._