### PR TITLE
Fix for Missing Override annotation

### DIFF
--- a/elasticsearch-evolution-core/src/main/java/com/senacor/elasticsearch/evolution/core/internal/model/migration/FileNameInfoImpl.java
+++ b/elasticsearch-evolution-core/src/main/java/com/senacor/elasticsearch/evolution/core/internal/model/migration/FileNameInfoImpl.java
@@ -33,7 +33,7 @@ public class FileNameInfoImpl implements FileNameInfo {
      * The name of the script to execute for this migration, relative to the configured location.
      * not-null
      */
-    @Getter
+    @Getter(onMethod_ = @Override)
     private final String scriptName;
 
     public FileNameInfoImpl(MigrationVersion version, String description, String scriptName) {


### PR DESCRIPTION
In general, the problem is that a method overriding a superclass or interface method is missing an `@Override` annotation. Because the getter is Lombok-generated, we cannot just add `@Override` above a concrete `getScriptName()` method; instead, we must instruct Lombok to place `@Override` on the generated method. Lombok supports this through `onMethod_ = @Annotation` in the `@Getter` annotation.

The best targeted fix is to modify the `@Getter` on the `scriptName` field so that Lombok generates `@Override` on the `getScriptName()` method. We leave the field and constructor logic unchanged. Concretely, in `elasticsearch-evolution-core/src/main/java/com/senacor/elasticsearch/evolution/core/internal/model/migration/FileNameInfoImpl.java`, change the `@Getter` on `private final String scriptName;` to `@Getter(onMethod_ = @Override)`. This does not require new imports because `Override` is in `java.lang`. No other fields necessarily need changes for this specific CodeQL finding, so we keep them as-is.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._