### PR TITLE
Fix for Missing Override annotation

### DIFF
--- a/elasticsearch-evolution-core/src/main/java/com/senacor/elasticsearch/evolution/core/internal/migration/input/MigrationScriptReaderImpl.java
+++ b/elasticsearch-evolution-core/src/main/java/com/senacor/elasticsearch/evolution/core/internal/migration/input/MigrationScriptReaderImpl.java
@@ -67,6 +67,7 @@ public class MigrationScriptReaderImpl implements MigrationScriptReader {
      *
      * @return a list of {@link RawMigrationScript}
      */
+    @Override
     public List<RawMigrationScript> read() {
         return this.locations.stream()
                 .flatMap(location -> {


### PR DESCRIPTION
In general, when a class implements an interface or extends a superclass and provides a method that overrides a method from that parent type, the method should be annotated with `@Override`. This gives you compile-time checking that the method correctly matches a method in the superclass or interface and improves readability.

The best fix here is to add the `@Override` annotation immediately above the `read()` method in `MigrationScriptReaderImpl`. Since annotations like `Override` are in `java.lang`, no new imports are required. This change does not alter functionality; it only informs the compiler and readers that this method is intended to implement the interface method.

Concretely: in `elasticsearch-evolution-core/src/main/java/com/senacor/elasticsearch/evolution/core/internal/migration/input/MigrationScriptReaderImpl.java`, locate the `public List<RawMigrationScript> read()` method (starting at line 70) and add a line with `@Override` directly above it. No other methods or regions need to be modified, and no additional support code or imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._