### PR TITLE
Fix for Missing Override annotation

### DIFF
--- a/elasticsearch-evolution-core/src/main/java/com/senacor/elasticsearch/evolution/core/internal/model/migration/FileNameInfoImpl.java
+++ b/elasticsearch-evolution-core/src/main/java/com/senacor/elasticsearch/evolution/core/internal/model/migration/FileNameInfoImpl.java
@@ -26,7 +26,7 @@ public class FileNameInfoImpl implements FileNameInfo {
      * migration description
      * not-null
      */
-    @Getter
+    @Getter(onMethod_ = {@Override})
     private final String description;
 
     /**


### PR DESCRIPTION
To fix this, the generated getter for `description` must be annotated with `@Override`. Because the method is generated by Lombok, we cannot directly add `@Override` to the method body in this file; instead, we configure Lombok’s `@Getter` annotation to add `@Override` to the generated method. Lombok provides the `onMethod` parameter that allows specifying annotations to be applied to the generated method.

Concretely, in `FileNameInfoImpl.java`, replace the bare `@Getter` on the `description` field (line 29) with `@Getter(onMethod_ = {@Override})`. This tells Lombok to generate:

```java
@Override
public String getDescription() { ... }
```

for that field. No changes are needed for the other fields unless CodeQL also flags them for the same rule. There is no need to add imports because `Override` is a built‑in annotation from `java.lang` and does not require an explicit import. This change preserves all existing functionality and only adds the desired annotation to the generated method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._