### PR TITLE
Fix for Missing Override annotation

### DIFF
--- a/elasticsearch-evolution-core/src/main/java/com/senacor/elasticsearch/evolution/core/internal/model/migration/RawMigrationScript.java
+++ b/elasticsearch-evolution-core/src/main/java/com/senacor/elasticsearch/evolution/core/internal/model/migration/RawMigrationScript.java
@@ -33,6 +33,7 @@ public class RawMigrationScript {
         return this;
     }
 
+    @Override
     public String toString() {
         return "filename: " + fileName + ", content: " + content;
     }


### PR DESCRIPTION
In general, to fix this kind of issue, you add the `@Override` annotation to any method that is intended to override a method from a superclass or implement a method from an interface. This allows the compiler to verify the override and improves readability.

For this specific class, the best fix without changing functionality is to add `@Override` immediately above the `toString` method declaration. No new imports are needed because `@Override` is part of `java.lang` and is implicitly available. The change is localized to `RawMigrationScript.java` around line 36: transform

```java
public String toString() {
    ...
}
```

into

```java
@Override
public String toString() {
    ...
}
```

No other methods or fields need to be modified, and no additional definitions or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._