### PR TITLE
update Elasticsearch versions and spring boot versions

### DIFF
--- a/.github/workflows/maven-matrix.yml
+++ b/.github/workflows/maven-matrix.yml
@@ -40,8 +40,8 @@ jobs:
   build-with-es:
     strategy:
       matrix:
-        elasticsearchVersion: [ "9.3.1", "9.2.6", "9.1.10", "9.0.8",
-                                "8.19.12"]
+        elasticsearchVersion: [ "9.3.2", "9.2.7", "9.1.10", "9.0.8",
+                                "8.19.13"]
       fail-fast: false
     runs-on: ubuntu-24.04
     steps:

--- a/elasticsearch-evolution-core/src/test/java/com/senacor/elasticsearch/evolution/core/test/EmbeddedElasticsearchExtension.java
+++ b/elasticsearch-evolution-core/src/test/java/com/senacor/elasticsearch/evolution/core/test/EmbeddedElasticsearchExtension.java
@@ -50,9 +50,9 @@ public class EmbeddedElasticsearchExtension implements TestInstancePostProcessor
             ofOpensearch("3.4.0"),
             ofOpensearch("2.19.4"),
 
-            ofElasticsearch("9.3.1"),
-            ofElasticsearch("9.2.6"),
-            ofElasticsearch("8.19.12")
+            ofElasticsearch("9.3.2"),
+            ofElasticsearch("9.2.7"),
+            ofElasticsearch("8.19.13")
     )));
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>3.5.11</version>
+        <version>3.5.12</version>
     </parent>
 
     <name>elasticsearch-evolution</name>
@@ -108,7 +108,7 @@
         <!-- Dependency Versions -->
         <commons-io.version>2.21.0</commons-io.version>
         <!--when updating elasticsearch versions, also update "ElasticsearchContainer" version in EmbeddedElasticsearchExtension-->
-        <elasticsearch.version>8.19.12</elasticsearch.version>
+        <elasticsearch.version>8.19.13</elasticsearch.version>
         <elasticsearch-rest5-client.version>9.3.3</elasticsearch-rest5-client.version>
         <opensearch-java3.version>3.7.0</opensearch-java3.version>
         <opensearch-java2.version>2.26.0</opensearch-java2.version>

--- a/spring-boot-starter-elasticsearch-evolution/src/test/java/com/senacor/elasticsearch/evolution/spring/boot/starter/autoconfigure/EmbeddedElasticsearchConfiguration.java
+++ b/spring-boot-starter-elasticsearch-evolution/src/test/java/com/senacor/elasticsearch/evolution/spring/boot/starter/autoconfigure/EmbeddedElasticsearchConfiguration.java
@@ -16,7 +16,7 @@ public class EmbeddedElasticsearchConfiguration {
 
     @Bean(destroyMethod = "stop")
     public ElasticsearchContainer elasticsearchContainer() {
-        ElasticsearchContainer container = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:8.19.12")
+        ElasticsearchContainer container = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:8.19.13")
                 .withEnv("ES_JAVA_OPTS", "-Xms128m -Xmx128m")
                 // since elasticsearch 8 security / https is enabled per default - but for testing it should be disabled
                 .withEnv("xpack.security.enabled", "false");

--- a/tests-elasticsearch/pom.xml
+++ b/tests-elasticsearch/pom.xml
@@ -14,7 +14,7 @@
     <description>aggregator module for integration test projects with Elasticsearch</description>
 
     <properties>
-        <elasticsearch.version>8.19.12</elasticsearch.version>
+        <elasticsearch.version>8.19.13</elasticsearch.version>
     </properties>
 
     <modules>

--- a/tests-elasticsearch/test-es-spring-boot-3.3-scriptsInJarFile/pom.xml
+++ b/tests-elasticsearch/test-es-spring-boot-3.3-scriptsInJarFile/pom.xml
@@ -17,7 +17,7 @@
         <java.version>17</java.version>
 
         <commons-io.version>2.21.0</commons-io.version>
-        <elasticsearch.version>8.19.12</elasticsearch.version>
+        <elasticsearch.version>8.19.13</elasticsearch.version>
         <testcontainers.elasticsearch.version>2.0.3</testcontainers.elasticsearch.version>
         <!-- the mockito version from spring-boot 3.3 is too old for mockito-maven-plugin -->
         <mockito.version>5.14.2</mockito.version>

--- a/tests-elasticsearch/test-es-spring-boot-3.3-scriptsInJarFile/src/test/java/com/senacor/elasticsearch/evolution/springboot33/ApplicationTest.java
+++ b/tests-elasticsearch/test-es-spring-boot-3.3-scriptsInJarFile/src/test/java/com/senacor/elasticsearch/evolution/springboot33/ApplicationTest.java
@@ -35,7 +35,7 @@ class ApplicationTest {
     @TestConfiguration
     static class Config {
         @Bean(destroyMethod = "stop")
-        public ElasticsearchContainer elasticsearchContainer(@Value("${elasticsearch.version:8.19.12}") String esVersion) {
+        public ElasticsearchContainer elasticsearchContainer(@Value("${elasticsearch.version:8.19.13}") String esVersion) {
             ElasticsearchContainer container = new ElasticsearchContainer(DockerImageName
                     .parse("docker.elastic.co/elasticsearch/elasticsearch")
                     .withTag(esVersion)) {

--- a/tests-elasticsearch/test-es-spring-boot-3.4-scriptsInJarFile/pom.xml
+++ b/tests-elasticsearch/test-es-spring-boot-3.4-scriptsInJarFile/pom.xml
@@ -17,7 +17,7 @@
         <java.version>17</java.version>
 
         <commons-io.version>2.21.0</commons-io.version>
-        <elasticsearch.version>8.19.12</elasticsearch.version>
+        <elasticsearch.version>8.19.13</elasticsearch.version>
         <testcontainers.elasticsearch.version>2.0.3</testcontainers.elasticsearch.version>
     </properties>
 

--- a/tests-elasticsearch/test-es-spring-boot-3.4-scriptsInJarFile/src/test/java/com/senacor/elasticsearch/evolution/springboot34/ApplicationTest.java
+++ b/tests-elasticsearch/test-es-spring-boot-3.4-scriptsInJarFile/src/test/java/com/senacor/elasticsearch/evolution/springboot34/ApplicationTest.java
@@ -35,7 +35,7 @@ class ApplicationTest {
     @TestConfiguration
     static class Config {
         @Bean(destroyMethod = "stop")
-        public ElasticsearchContainer elasticsearchContainer(@Value("${elasticsearch.version:8.19.12}") String esVersion) {
+        public ElasticsearchContainer elasticsearchContainer(@Value("${elasticsearch.version:8.19.13}") String esVersion) {
             ElasticsearchContainer container = new ElasticsearchContainer(DockerImageName
                     .parse("docker.elastic.co/elasticsearch/elasticsearch")
                     .withTag(esVersion)) {

--- a/tests-elasticsearch/test-es-spring-boot-3.5/pom.xml
+++ b/tests-elasticsearch/test-es-spring-boot-3.5/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.11</version>
+		<version>3.5.12</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.senacor.elasticsearch.evolution</groupId>
@@ -17,7 +17,7 @@
 		<java.version>17</java.version>
 
 		<commons-io.version>2.21.0</commons-io.version>
-		<elasticsearch.version>8.19.12</elasticsearch.version>
+		<elasticsearch.version>8.19.13</elasticsearch.version>
 		<testcontainers.elasticsearch.version>2.0.3</testcontainers.elasticsearch.version>
 	</properties>
 

--- a/tests-elasticsearch/test-es-spring-boot-3.5/src/test/java/com/senacor/elasticsearch/evolution/springboot35/ApplicationTests.java
+++ b/tests-elasticsearch/test-es-spring-boot-3.5/src/test/java/com/senacor/elasticsearch/evolution/springboot35/ApplicationTests.java
@@ -35,7 +35,7 @@ class ApplicationTests {
     @TestConfiguration
     static class Config {
         @Bean(destroyMethod = "stop")
-        public ElasticsearchContainer elasticsearchContainer(@Value("${elasticsearch.version:8.19.12}") String esVersion) {
+        public ElasticsearchContainer elasticsearchContainer(@Value("${elasticsearch.version:8.19.13}") String esVersion) {
             ElasticsearchContainer container = new ElasticsearchContainer(DockerImageName
                     .parse("docker.elastic.co/elasticsearch/elasticsearch")
                     .withTag(esVersion)) {

--- a/tests-elasticsearch/test-es-spring-boot-4.0/pom.xml
+++ b/tests-elasticsearch/test-es-spring-boot-4.0/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.3</version>
+        <version>4.0.4</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.senacor.elasticsearch.evolution</groupId>
@@ -16,7 +16,7 @@
     <properties>
         <java.version>17</java.version>
 
-        <elasticsearch.version>8.19.12</elasticsearch.version>
+        <elasticsearch.version>8.19.13</elasticsearch.version>
     </properties>
 
     <dependencies>

--- a/tests-elasticsearch/test-es-spring-boot-4.0/src/test/java/com/senacor/elasticsearch/evolution/springboot40/ApplicationTest.java
+++ b/tests-elasticsearch/test-es-spring-boot-4.0/src/test/java/com/senacor/elasticsearch/evolution/springboot40/ApplicationTest.java
@@ -35,7 +35,7 @@ class ApplicationTest {
     @TestConfiguration
     static class Config {
         @Bean(destroyMethod = "stop")
-        public ElasticsearchContainer elasticsearchContainer(@Value("${elasticsearch.version:8.19.12}") String esVersion) {
+        public ElasticsearchContainer elasticsearchContainer(@Value("${elasticsearch.version:8.19.13}") String esVersion) {
             ElasticsearchContainer container = new ElasticsearchContainer(DockerImageName
                     .parse("docker.elastic.co/elasticsearch/elasticsearch")
                     .withTag(esVersion)) {

--- a/tests-elasticsearch/test-es-spring-boot-4.1/pom.xml
+++ b/tests-elasticsearch/test-es-spring-boot-4.1/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <java.version>17</java.version>
 
-        <elasticsearch.version>8.19.12</elasticsearch.version>
+        <elasticsearch.version>8.19.13</elasticsearch.version>
     </properties>
 
     <dependencies>

--- a/tests-elasticsearch/test-es-spring-boot-4.1/src/test/java/com/senacor/elasticsearch/evolution/springboot41/ApplicationTest.java
+++ b/tests-elasticsearch/test-es-spring-boot-4.1/src/test/java/com/senacor/elasticsearch/evolution/springboot41/ApplicationTest.java
@@ -35,7 +35,7 @@ class ApplicationTest {
     @TestConfiguration
     static class Config {
         @Bean(destroyMethod = "stop")
-        public ElasticsearchContainer elasticsearchContainer(@Value("${elasticsearch.version:8.19.12}") String esVersion) {
+        public ElasticsearchContainer elasticsearchContainer(@Value("${elasticsearch.version:8.19.13}") String esVersion) {
             ElasticsearchContainer container = new ElasticsearchContainer(DockerImageName
                     .parse("docker.elastic.co/elasticsearch/elasticsearch")
                     .withTag(esVersion)) {

--- a/tests-opensearch-genericclient/test-os-genericclient-spring-boot-3.5/pom.xml
+++ b/tests-opensearch-genericclient/test-os-genericclient-spring-boot-3.5/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.11</version>
+		<version>3.5.12</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.senacor.elasticsearch.evolution</groupId>

--- a/tests-opensearch-genericclient/test-os-genericclient-spring-boot-4.0/pom.xml
+++ b/tests-opensearch-genericclient/test-os-genericclient-spring-boot-4.0/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.3</version>
+		<version>4.0.4</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.senacor.elasticsearch.evolution</groupId>

--- a/tests-opensearch-restclient/test-os-restclient-spring-boot-3.5/pom.xml
+++ b/tests-opensearch-restclient/test-os-restclient-spring-boot-3.5/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.11</version>
+		<version>3.5.12</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.senacor.elasticsearch.evolution</groupId>

--- a/tests-opensearch-restclient/test-os-restclient-spring-boot-4.0/pom.xml
+++ b/tests-opensearch-restclient/test-os-restclient-spring-boot-4.0/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.3</version>
+		<version>4.0.4</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.senacor.elasticsearch.evolution</groupId>


### PR DESCRIPTION
update Elasticsearch version from 
9.3.1 to 9.3.2
9.2.6 to 9.2.7
8.19.12 to 8.19.13

update Spring boot version from
3.5.11 to 3.5.12
4.0.3 to 4.0.4